### PR TITLE
Added SMART monitoring based on smartctl

### DIFF
--- a/scripts/ugreen-diskiomon
+++ b/scripts/ugreen-diskiomon
@@ -4,7 +4,7 @@ possible_devices=(sda sdb sdc sdd sde sdf sdg sdh)
 led_map=(disk1 disk2 disk3 disk4 disk5 disk6 disk7 disk8)
 devices=()
 
-# check disk SMART information
+# check dist SMART information
 CHECK_SMART=true
 # roughly 360 seconds by default
 smart_pool_interval=3600
@@ -47,6 +47,7 @@ while true; do
         if [[ ! -f /sys/class/block/${dev}/stat ]]; then
             if [[ -f /sys/class/leds/${led_map[$i]}/color ]]; then 
                 echo "255 0 0" > /sys/class/leds/${led_map[$i]}/color
+                echo Disk /dev/$dev offline
             fi
             continue
         fi
@@ -55,9 +56,9 @@ while true; do
         cnt=$(($cnt+1))
         cnt=$(($cnt%${smart_pool_interval}))
         if [ "$CHECK_SMART" = true ] && [[ ${cnt} -eq 0 ]]; then
-            if [[ -z $(smartctl -H ${dev} | grep SUCCESS) ]]; then
+            if [[ -z $(smartctl -H /dev/${dev} | grep PASSED) ]]; then
                 echo "255 0 0" > /sys/class/leds/${led_map[$i]}/color
-                echo Disk failure detected
+                echo Disk failure detected on /dev/$dev
                 continue
             fi
         fi

--- a/scripts/ugreen-diskiomon
+++ b/scripts/ugreen-diskiomon
@@ -1,7 +1,13 @@
 #!/usr/bin/bash
 
-devices=(sda sdb sdc sdd sde sdf sdg sdh)
+possible_devices=(sda sdb sdc sdd sde sdf sdg sdh)
 led_map=(disk1 disk2 disk3 disk4 disk5 disk6 disk7 disk8)
+devices=()
+
+# check disk SMART information
+CHECK_SMART=true
+# roughly 360 seconds by default
+smart_pool_interval=3600
 
 diskio_data_r=()
 diskio_data_w=()
@@ -10,17 +16,29 @@ diskio_data_w=()
 
 sleep 2
 
-for led in ${led_map[@]}; do 
+for i in "${!led_map[@]}"; do
+    led=${led_map[i]} 
     if [[ -d /sys/class/leds/$led ]]; then
         echo oneshot > /sys/class/leds/$led/trigger
         echo 1 > /sys/class/leds/$led/invert
         echo 100 > /sys/class/leds/$led/delay_on
         echo 100 > /sys/class/leds/$led/delay_off
+        echo "255 255 255" > /sys/class/leds/$led/color
+        dev=${possible_devices[i]}
+        if [[ -f /sys/class/block/${dev}/stat ]]; then
+            devices+=(${dev})
+        else
+            # turn off the led if no disk installed on this slot
+            echo 0 > /sys/class/leds/$led/brightness
+            echo none > /sys/class/leds/$led/trigger
+        fi
     fi
 done
 
-while true; do
+echo detected SATA drives: ${devices[@]}
 
+let loop_cnt=0
+while true; do
     for i in "${!devices[@]}"; do
         dev=${devices[$i]}
         diskio_old_r=${diskio_data_r[$i]}
@@ -31,6 +49,17 @@ while true; do
                 echo "255 0 0" > /sys/class/leds/${led_map[$i]}/color
             fi
             continue
+        fi
+
+        # check disk health
+        cnt=$(($cnt+1))
+        cnt=$(($cnt%${smart_pool_interval}))
+        if [ "$CHECK_SMART" = true ] && [[ ${cnt} -eq 0 ]]; then
+            if [[ -z $(smartctl -H ${dev} | grep SUCCESS) ]]; then
+                echo "255 0 0" > /sys/class/leds/${led_map[$i]}/color
+                echo Disk failure detected
+                continue
+            fi
         fi
 
         diskio_new_r=$(cat /sys/block/${dev}/stat | awk '{ print $1 }')

--- a/scripts/ugreen-diskiomon
+++ b/scripts/ugreen-diskiomon
@@ -63,8 +63,8 @@ for i in "${!led_map[@]}"; do
     fi
 done
 
-diskio_data_r=()
-diskio_data_w=()
+declare -A diskio_data_r
+declare -A diskio_data_w
 let loop_cnt=0
 while true; do
     for led in "${!devices[@]}"; do

--- a/scripts/ugreen-diskiomon
+++ b/scripts/ugreen-diskiomon
@@ -1,20 +1,44 @@
 #!/usr/bin/bash
 
-possible_devices=(sda sdb sdc sdd sde sdf sdg sdh)
+# led-disk mapping
+mapping_method=hctl  # hctl, serial
 led_map=(disk1 disk2 disk3 disk4 disk5 disk6 disk7 disk8)
-devices=()
+# hctl, $> lsblk -S -o name,hctl
+hctl_map=("0:0:0:0" "1:0:0:0" "2:0:0:0" "3:0:0:0" "4:0:0:0" "5:0:0:0" "6:0:0:0" "7:0:0:0")
+# serial number, $> lsblk -S -o name,serial
+serial_map=("placeholder0" "placeholder1" "placeholder2" "placeholder3" "placeholder4" "placeholder5" "placeholder6" "placeholder7")
+declare -A devices
 
-# check dist SMART information
+# monitor dist SMART information
 CHECK_SMART=true
-# roughly 360 seconds by default
-smart_pool_interval=3600
+# polling rate for smartctl. roughly 360 seconds by default
+smart_poll_interval=3600
 
-diskio_data_r=()
-diskio_data_w=()
+
+
 
 { lsmod | grep ledtrig_oneshot ; } || modprobe -v ledtrig_oneshot
 
 sleep 2
+
+echo Enumerating disks based on $mapping_method...
+declare -A dev_map
+while read line
+do
+    blk_line=($line)
+    if [[ $mapping_method = hctl ]]; then
+        key=${blk_line[1]}
+        val=${blk_line[0]}
+    elif [[ $mapping_method = serial ]]; then
+        key=${blk_line[1]}
+        val=${blk_line[0]}
+    else
+        echo Unsupported mapping method: ${mapping_method}
+        exit 1
+    fi
+    dev_map[${key}]=${val}
+    echo $mapping_method ${key} ">>" ${dev_map[${key}]}
+done <<< "$(lsblk -S -o name,${mapping_method} | tail -n +2)"
 
 for i in "${!led_map[@]}"; do
     led=${led_map[i]} 
@@ -24,9 +48,13 @@ for i in "${!led_map[@]}"; do
         echo 100 > /sys/class/leds/$led/delay_on
         echo 100 > /sys/class/leds/$led/delay_off
         echo "255 255 255" > /sys/class/leds/$led/color
-        dev=${possible_devices[i]}
+
+        # find corresponding device
+        _tmp_str=${mapping_method}_map[@]
+        _tmp_arr=(${!_tmp_str})
+        dev=${dev_map[${_tmp_arr[i]}]}
         if [[ -f /sys/class/block/${dev}/stat ]]; then
-            devices+=(${dev})
+            devices[$led]=${dev}
         else
             # turn off the led if no disk installed on this slot
             echo 0 > /sys/class/leds/$led/brightness
@@ -35,30 +63,32 @@ for i in "${!led_map[@]}"; do
     fi
 done
 
-echo detected SATA drives: ${devices[@]}
-
+diskio_data_r=()
+diskio_data_w=()
 let loop_cnt=0
 while true; do
-    for i in "${!devices[@]}"; do
-        dev=${devices[$i]}
-        diskio_old_r=${diskio_data_r[$i]}
-        diskio_old_w=${diskio_data_w[$i]}
+    for led in "${!devices[@]}"; do
+        dev=${devices[$led]}
+        diskio_old_r=${diskio_data_r[$led]}
+        diskio_old_w=${diskio_data_w[$led]}
+
+        if [[ "$(cat /sys/class/leds/$led/color)" = "255 0 0" ]]; then
+            continue;
+        fi
 
         if [[ ! -f /sys/class/block/${dev}/stat ]]; then
-            if [[ -f /sys/class/leds/${led_map[$i]}/color ]]; then 
-                echo "255 0 0" > /sys/class/leds/${led_map[$i]}/color
-                echo Disk /dev/$dev offline
+            if [[ -f /sys/class/leds/$led/color ]]; then 
+                echo "255 0 0" > /sys/class/leds/$led/color
+                echo Disk /dev/$dev went offline at $(date +%Y-%m-%d' '%H:%M:%S)
+                continue
             fi
-            continue
         fi
 
         # check disk health
-        cnt=$(($cnt+1))
-        cnt=$(($cnt%${smart_pool_interval}))
-        if [ "$CHECK_SMART" = true ] && [[ ${cnt} -eq 0 ]]; then
+        if [ "$CHECK_SMART" = true ] && [[ ${loop_cnt} -eq 0 ]]; then
             if [[ -z $(smartctl -H /dev/${dev} | grep PASSED) ]]; then
-                echo "255 0 0" > /sys/class/leds/${led_map[$i]}/color
-                echo Disk failure detected on /dev/$dev
+                echo "255 0 0" > /sys/class/leds/$led/color
+                echo Disk failure detected on /dev/$dev at $(date +%Y-%m-%d' '%H:%M:%S)
                 continue
             fi
         fi
@@ -67,11 +97,11 @@ while true; do
         diskio_new_w=$(cat /sys/block/${dev}/stat | awk '{ print $4 }')
 
         if [ "${diskio_old_r}" != "${diskio_new_r}" ] || [ "${diskio_old_w}" != "${diskio_new_w}" ]; then
-            echo 1 > /sys/class/leds/${led_map[$i]}/shot
+            echo 1 > /sys/class/leds/$led/shot
         fi
 
-        diskio_data_r[$i]=$diskio_new_r
-        diskio_data_w[$i]=$diskio_new_w
+        diskio_data_r[$led]=$diskio_new_r
+        diskio_data_w[$led]=$diskio_new_w
     done
 
     if [ -f /usr/bin/zpool-leds.sh ]; then
@@ -79,5 +109,7 @@ while true; do
     fi
 
     sleep 0.1
+    loop_cnt=$(($loop_cnt+1))
+    loop_cnt=$(($loop_cnt%${smart_poll_interval}))
 
 done


### PR DESCRIPTION
The disk failure reported by `smartctl -H` will be reflected on leds.
Empty slots will have corresponding leds turned off.
The sata devices are now mapped to leds based on hctl by default.
Also added an option to map devices based on their serial numbers. (serial numbers must be manually configured)
Fixed a bug in SMART polling invertal control.
Failed disk will be marked and left untouched. The failure date will be recorded.