### PR TITLE
Few changes

### DIFF
--- a/scripts/ugreen-diskiomon
+++ b/scripts/ugreen-diskiomon
@@ -124,11 +124,14 @@ if [ "$CHECK_SMART" = true ]; then
                 continue;
             fi
 
+            dev=${devices[$led]}
+
             if [[ -z $(smartctl -H /dev/${dev} | grep PASSED) ]]; then
                 echo "255 0 0" > /sys/class/leds/$led/color
                 echo Disk failure detected on /dev/$dev at $(date +%Y-%m-%d' '%H:%M:%S)
                 continue
             fi
+        done
         sleep ${CHECK_SMART_INTERVAL}s
     done
 ) &

--- a/scripts/ugreen-diskiomon
+++ b/scripts/ugreen-diskiomon
@@ -1,7 +1,25 @@
 #!/usr/bin/bash
 
+# function for removing lockfile
+exit-ugreen-diskiomon() {
+  if [[ -f "/var/run/ugreen-diskiomon.lock" ]]; then
+    rm "/var/run/ugreen-diskiomon.lock"
+  fi
+  kill $smart_check_pid 2>/dev/null
+}
+
+# trap exit and remove lockfile
+trap 'exit-ugreen-diskiomon' EXIT
+
+# check if script is already running
+if [[ -f "/var/run/ugreen-diskiomon.lock" ]]; then
+  echo "ugreen-diskiomon already running!"
+  exit 1
+fi
+touch /var/run/ugreen-diskiomon.lock
+
 # led-disk mapping (see https://github.com/miskcoo/ugreen_dx4600_leds_controller/pull/4)
-mapping_method=hctl  # hctl, serial
+mapping_method=${mapping_method:=hctl} # hctl, serial
 led_map=(disk1 disk2 disk3 disk4 disk5 disk6 disk7 disk8)
 
 # hctl, $> lsblk -S -x hctl -o hctl,serial,name 
@@ -38,11 +56,16 @@ fi
 serial_map=("placeholder0" "placeholder1" "placeholder2" "placeholder3" "placeholder4" "placeholder5" "placeholder6" "placeholder7")
 declare -A devices
 
-# monitor dist SMART information
-CHECK_SMART=true
-# polling rate for smartctl. roughly 360 seconds by default
-smart_poll_interval=3600
-
+# set monitor SMART information to true by default if not running unRAID
+if [[ -f /etc/unraid-version ]]; then
+    CHECK_SMART=false
+else
+    CHECK_SMART=${CHECK_SMART:=true}
+fi
+# polling rate for smartctl. 360 seconds by default
+CHECK_SMART_INTERVAL=${CHECK_SMART_INTERVAL:=360}
+# refresh interval from disk leds
+LED_REFRESH_INTERVAL=${LED_REFRESH_INTERVAL:=0.1}
 
 
 
@@ -92,9 +115,35 @@ for i in "${!led_map[@]}"; do
     fi
 done
 
+# check disk health if enabled
+if [ "$CHECK_SMART" = true ]; then
+(
+    while true; do
+        for led in "${!devices[@]}"; do
+            if [[ "$(cat /sys/class/leds/$led/color)" = "255 0 0" ]]; then
+                continue;
+            fi
+
+            if [[ -z $(smartctl -H /dev/${dev} | grep PASSED) ]]; then
+                echo "255 0 0" > /sys/class/leds/$led/color
+                echo Disk failure detected on /dev/$dev at $(date +%Y-%m-%d' '%H:%M:%S)
+                continue
+            fi
+        sleep ${CHECK_SMART_INTERVAL}s
+    done
+) &
+smart_check_pid=$!
+fi
+
+# check for zpool-leds.sh and set variable
+if [[ -f /usr/bin/zpool-leds.sh ]]; then
+    ZPOOL_LEDS="bash /usr/bin/zpool-leds.sh"
+else
+    ZPOOL_LEDS=""
+fi
+
 declare -A diskio_data_r
 declare -A diskio_data_w
-let loop_cnt=0
 while true; do
     for led in "${!devices[@]}"; do
         dev=${devices[$led]}
@@ -106,20 +155,9 @@ while true; do
         fi
 
         if [[ ! -f /sys/class/block/${dev}/stat ]]; then
-            if [[ -f /sys/class/leds/$led/color ]]; then 
-                echo "255 0 0" > /sys/class/leds/$led/color
-                echo Disk /dev/$dev went offline at $(date +%Y-%m-%d' '%H:%M:%S)
-                continue
-            fi
-        fi
-
-        # check disk health
-        if [ "$CHECK_SMART" = true ] && [[ ${loop_cnt} -eq 0 ]]; then
-            if [[ -z $(smartctl -H /dev/${dev} | grep PASSED) ]]; then
-                echo "255 0 0" > /sys/class/leds/$led/color
-                echo Disk failure detected on /dev/$dev at $(date +%Y-%m-%d' '%H:%M:%S)
-                continue
-            fi
+            echo "255 0 0" > /sys/class/leds/$led/color 2>/dev/null
+            echo Disk /dev/$dev went offline at $(date +%Y-%m-%d' '%H:%M:%S)
+            continue
         fi
 
         diskio_new_r=$(cat /sys/block/${dev}/stat | awk '{ print $1 }')
@@ -133,12 +171,8 @@ while true; do
         diskio_data_w[$led]=$diskio_new_w
     done
 
-    if [ -f /usr/bin/zpool-leds.sh ]; then
-        bash /usr/bin/zpool-leds.sh
-    fi
+    ${ZPOOL_LEDS}
 
-    sleep 0.1
-    loop_cnt=$(($loop_cnt+1))
-    loop_cnt=$(($loop_cnt%${smart_poll_interval}))
+    sleep ${LED_REFRESH_INTERVAL}s
 
 done

--- a/scripts/ugreen-diskiomon
+++ b/scripts/ugreen-diskiomon
@@ -18,8 +18,13 @@ if [[ -f "/var/run/ugreen-diskiomon.lock" ]]; then
 fi
 touch /var/run/ugreen-diskiomon.lock
 
+# use variables from config file (unRAID specific)
+if [[ -f /boot/config/plugins/ugreenleds-driver/settings.cfg ]]; then
+  source /boot/config/plugins/ugreenleds-driver/settings.cfg
+fi
+
 # led-disk mapping (see https://github.com/miskcoo/ugreen_dx4600_leds_controller/pull/4)
-mapping_method=${mapping_method:=hctl} # hctl, serial
+MAPPING_METHOD=${MAPPING_METHOD:=hctl} # hctl, serial
 led_map=(disk1 disk2 disk3 disk4 disk5 disk6 disk7 disk8)
 
 # hctl, $> lsblk -S -x hctl -o hctl,serial,name 
@@ -42,14 +47,14 @@ if which dmidecode; then
           # using the default mapping
           ;;
         *)
-          if [[ "${mapping_method}" = "hctl" ]]; then
+          if [[ "${MAPPING_METHOD}" = "hctl" ]]; then
               echo "Using the default HCTL order. Please check it maps to your disk slots correctly."
               echo "If you confirm that the HCTL order is correct, or find it is different, you can submit an issue to let us know, so we can update the script."
               echo "(Read the disk mapping section in https://github.com/miskcoo/ugreen_dx4600_leds_controller/blob/master/README.md for more details)"
           fi
           ;;
     esac
-elif [[ "${mapping_method}" = "hctl" ]]; then
+elif [[ "${MAPPING_METHOD}" = "hctl" ]]; then
     echo "installing the tool `dmidecode` is suggested; otherwise the script cannot detect your device and adjust the hctl_map"
 fi 
 # serial number, $> lsblk -S -x hctl -o hctl,serial,name 
@@ -73,24 +78,24 @@ LED_REFRESH_INTERVAL=${LED_REFRESH_INTERVAL:=0.1}
 
 sleep 2
 
-echo Enumerating disks based on $mapping_method...
+echo Enumerating disks based on $MAPPING_METHOD...
 declare -A dev_map
 while read line
 do
     blk_line=($line)
-    if [[ $mapping_method = hctl ]]; then
+    if [[ $MAPPING_METHOD = hctl ]]; then
         key=${blk_line[1]}
         val=${blk_line[0]}
-    elif [[ $mapping_method = serial ]]; then
+    elif [[ $MAPPING_METHOD = serial ]]; then
         key=${blk_line[1]}
         val=${blk_line[0]}
     else
-        echo Unsupported mapping method: ${mapping_method}
+        echo Unsupported mapping method: ${MAPPING_METHOD}
         exit 1
     fi
     dev_map[${key}]=${val}
-    echo $mapping_method ${key} ">>" ${dev_map[${key}]}
-done <<< "$(lsblk -S -o name,${mapping_method} | tail -n +2)"
+    echo $MAPPING_METHOD ${key} ">>" ${dev_map[${key}]}
+done <<< "$(lsblk -S -o name,${MAPPING_METHOD} | tail -n +2)"
 
 for i in "${!led_map[@]}"; do
     led=${led_map[i]} 
@@ -102,7 +107,7 @@ for i in "${!led_map[@]}"; do
         echo "255 255 255" > /sys/class/leds/$led/color
 
         # find corresponding device
-        _tmp_str=${mapping_method}_map[@]
+        _tmp_str=${MAPPING_METHOD}_map[@]
         _tmp_arr=(${!_tmp_str})
         dev=${dev_map[${_tmp_arr[i]}]}
         if [[ -f /sys/class/block/${dev}/stat ]]; then

--- a/scripts/ugreen-diskiomon
+++ b/scripts/ugreen-diskiomon
@@ -145,13 +145,11 @@ else
     ZPOOL_LEDS=""
 fi
 
-declare -A diskio_data_r
-declare -A diskio_data_w
+declare -A diskio_data_rw
 while true; do
     for led in "${!devices[@]}"; do
         dev=${devices[$led]}
-        diskio_old_r=${diskio_data_r[$led]}
-        diskio_old_w=${diskio_data_w[$led]}
+        diskio_old_rw="${diskio_data_rw[$led]}"
 
         if [[ "$(cat /sys/class/leds/$led/color)" = "255 0 0" ]]; then
             continue;
@@ -163,15 +161,13 @@ while true; do
             continue
         fi
 
-        diskio_new_r=$(cat /sys/block/${dev}/stat | awk '{ print $1 }')
-        diskio_new_w=$(cat /sys/block/${dev}/stat | awk '{ print $5 }')
+        diskio_new_rw="$(cat /sys/block/${dev}/stat)"
 
-        if [ "${diskio_old_r}" != "${diskio_new_r}" ] || [ "${diskio_old_w}" != "${diskio_new_w}" ]; then
+        if [ "${diskio_old_rw}" != "${diskio_new_rw}" ]; then
             echo 1 > /sys/class/leds/$led/shot
         fi
 
-        diskio_data_r[$led]=$diskio_new_r
-        diskio_data_w[$led]=$diskio_new_w
+        diskio_data_rw[$led]=$diskio_new_rw
     done
 
     ${ZPOOL_LEDS}


### PR DESCRIPTION
- create lock file on script execution
- create function to to remove lockfile and kill subprocess if running
- trap exit from script
- check if environment variables are set for: `mapping_method`, `CHECK_SMART`& `CHECK_SMART_INTERVAL` otherwise use default values
- set `CHECK_SMART` to false if file `/etc/unraid-release` is found (unRAID specific since it check on it's own for smart errors)
- create variable `LED_REFRESH_INTERVAL` for while looop
- run smart check in subprocess
- put `zpool-leds.sh` in a variable to make the while loop a bit more efficient
- remove check for `/sys/class/leds/$led/color` and set color <- I'm not too sure about that one but this path should always exist correct?