### PR TITLE
Fixes

### DIFF
--- a/scripts/ugreen-leds.conf
+++ b/scripts/ugreen-leds.conf
@@ -60,7 +60,8 @@ CHECK_ZPOOL=false
 # The sleep time between two zpool checks (default: 5 seconds)
 CHECK_ZPOOL_INTERVAL=5
 
-# The sleep time between two disk online checks (default: 5 seconds) CHECK_DISK_ONLINE_INTERVAL=5
+# The sleep time between two disk online checks (default: 5 seconds) 
+CHECK_DISK_ONLINE_INTERVAL=5
 
 
 # =========== parameters of network activities monitoring =========== 

--- a/scripts/ugreen-probe-leds
+++ b/scripts/ugreen-probe-leds
@@ -9,7 +9,7 @@ i2c_dev=$(i2cdetect -l | grep "SMBus I801 adapter" | grep -Po "i2c-\d+")
 
 if [ $? = 0 ]; then 
         echo "Found I2C device /dev/${i2c_dev}"
-        echo "led-ugreen 0x3a" > /sys/bus/i2c/devices/${i2c_dev}/new_device || true
+        echo "led-ugreen 0x3a" > /sys/bus/i2c/devices/${i2c_dev}/new_device 2>/dev/null || true
 else
         echo "I2C device not found!"
 fi


### PR DESCRIPTION
2 small fixes

first commit fix the output in systemctl.

`line 12: echo: write error: Device or resource busy` could be missunderstood
![image](https://github.com/miskcoo/ugreen_dx4600_leds_controller/assets/1573025/93f939c2-8484-4d46-a84d-802e1c909a63)

second commit fix just formating stuff
