### PR TITLE
Adjust systemd units to wait for kernel modules to be loaded

### DIFF
--- a/scripts/ugreen-diskiomon.service
+++ b/scripts/ugreen-diskiomon.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=UGREEN LEDs daemon for monitoring diskio and blinking corresponding LEDs
+After=systemd-modules-load.service
+Requires=systemd-modules-load.service
 
 [Service]
 ExecStartPre=/usr/bin/ugreen-probe-leds

--- a/scripts/ugreen-netdevmon@.service
+++ b/scripts/ugreen-netdevmon@.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=UGREEN LEDs daemon for monitoring netio (of %i) and blinking corresponding LEDs
+After=systemd-modules-load.service
+Requires=systemd-modules-load.service
 
 [Service]
 ExecStartPre=/usr/bin/ugreen-probe-leds


### PR DESCRIPTION
diskiomon and netdevmon often starts before their kernel modules are loaded by systemd.
Adjust unit file so they are started AFTER kernel modules