### PR TITLE
Support DKMS specified kernel version

### DIFF
--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -3,6 +3,6 @@ obj-m += led-ugreen.o
 ccflags-y := -std=gnu11
 
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	make -C /lib/modules/$(KERNELRELEASE)/build M=$(PWD) modules
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	make -C /lib/modules/$(KERNELRELEASE)/build M=$(PWD) clean

--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -2,6 +2,9 @@ TARGET = led-ugreen
 obj-m += led-ugreen.o
 ccflags-y := -std=gnu11
 
+# if KERNELRELEASE isn't set, i.e. not being built w/ DMKS, then use uname -r
+KERNELRELEASE ?= $(shell uname -r)
+
 all:
 	make -C /lib/modules/$(KERNELRELEASE)/build M=$(PWD) modules
 clean:


### PR DESCRIPTION
For the module to be built automatically by hooks in various package managers (I'm testing with pacman/yay), KERNELRELEASE needs to be the source of the kernel version to build.

Tested by installing 6.11.3-zen1-1-zen and headers, 