### PR TITLE
Don't mark drives in standby as failed

### DIFF
--- a/scripts/ugreen-diskiomon
+++ b/scripts/ugreen-diskiomon
@@ -274,7 +274,8 @@ if [ "$CHECK_SMART" = true ]; then
 
             dev=${devices[$led]}
 
-            /usr/sbin/smartctl -H /dev/${dev} -n standby,1 &> /dev/null
+            # read the smart status return code, but ignore if the drive is on standby
+            /usr/sbin/smartctl -H /dev/${dev} -n standby,0 &> /dev/null
             RET=$?
 
             # check return code for critical errors (any bit set except bit 5)


### PR DESCRIPTION
The standby return code of smartctl is updated to 0 to avoid detecting it as a failure.

fixes https://github.com/miskcoo/ugreen_leds_controller/issues/58