### PR TITLE
ugreen-diskiomon: trap to remove lock file must be enabled after the …

### DIFF
--- a/scripts/ugreen-diskiomon
+++ b/scripts/ugreen-diskiomon
@@ -5,10 +5,10 @@ exit-ugreen-diskiomon() {
   if [[ -f "/var/run/ugreen-diskiomon.lock" ]]; then
     rm "/var/run/ugreen-diskiomon.lock"
   fi
-  kill $smart_check_pid 2>/dev/null
-  kill $zpool_check_pid 2>/dev/null
-  kill $disk_online_check_pid 2>/dev/null
-  kill $standby_checker_pid 2>/dev/null
+  [[ -n "$smart_check_pid" ]] && kill $smart_check_pid 2>/dev/null
+  [[ -n "$zpool_check_pid" ]] && kill $zpool_check_pid 2>/dev/null
+  [[ -n "$disk_online_check_pid" ]] kill $disk_online_check_pid 2>/dev/null
+  [[ -n "$standby_checker_pid" ]] && kill $standby_checker_pid 2>/dev/null
 }
 
 # check if script is already running


### PR DESCRIPTION
**ugreen-diskiomon: trap to remove lock file must be enabled after the already running check**

If you start the script while the script is already running (the lockfile exists) the script executes an "exit 1" statement. Then, if the trap is already set, it will be executed; thus removing the lockfile and leaving the previous instance running.
