### PR TITLE
Graceful exit when no SATA drives are present in bays

### DIFF
--- a/scripts/ugreen-diskiomon
+++ b/scripts/ugreen-diskiomon
@@ -146,6 +146,7 @@ do
     blk_line=($line)
     key=${blk_line[1]}
     val=${blk_line[0]}
+    [[ -z "$key" ]] && continue
     dev_map[${key}]=${val}
     echo $MAPPING_METHOD ${key} ">>" ${dev_map[${key}]}
 done <<< "$(disk_enumerating_string)"
@@ -165,7 +166,7 @@ for i in "${!led_map[@]}"; do
         # find corresponding device
         _tmp_str=${MAPPING_METHOD}_map[@]
         _tmp_arr=(${!_tmp_str})
-        
+
         if [[ -v "dev_map[${_tmp_arr[i]}]" ]]; then
             dev=${dev_map[${_tmp_arr[i]}]}
 
@@ -185,6 +186,12 @@ for i in "${!led_map[@]}"; do
     fi
 done
 
+# early exit if all bays are empty
+if [[ ${#devices[@]} -eq 0 ]]; then
+    echo "No ATA disk devices found in bays, disk LED monitoring disabled."
+    exit 0
+fi
+
 # construct zpool device mapping
 declare -A zpool_ledmap
 if [ "$CHECK_ZPOOL" = true ]; then
@@ -192,7 +199,7 @@ if [ "$CHECK_ZPOOL" = true ]; then
     while read line
     do
         zpool_dev_line=($line)
-        zpool_dev_name=${zpool_dev_line[0]} 
+        zpool_dev_name=${zpool_dev_line[0]}
         zpool_scsi_dev_name="unknown"
         # zpool_dev_state=${zpool_dev_line[1]}
         case "$zpool_dev_name" in
@@ -210,7 +217,7 @@ if [ "$CHECK_ZPOOL" = true ]; then
                 ;;
         esac
 
-        # if the detected scsi device can be found in the mapping array 
+        # if the detected scsi device can be found in the mapping array
         #echo zpool $zpool_dev_name ">>" $zpool_scsi_dev_name ">>" ${dev_to_led_map[${zpool_scsi_dev_name}]}
         if [[ -v "dev_to_led_map[${zpool_scsi_dev_name}]" ]]; then
             zpool_ledmap[$zpool_dev_name]=${dev_to_led_map[${zpool_scsi_dev_name}]}
@@ -223,7 +230,7 @@ if [ "$CHECK_ZPOOL" = true ]; then
             while read line
             do
                 zpool_dev_line=($line)
-                zpool_dev_name=${zpool_dev_line[0]} 
+                zpool_dev_name=${zpool_dev_line[0]}
                 zpool_dev_state=${zpool_dev_line[1]}
 
                 # TODO: do something if the pool is unhealthy?
@@ -335,7 +342,7 @@ if [ -f "${BLINK_MON_PATH}" ]; then
 
     ${BLINK_MON_PATH} ${LED_REFRESH_INTERVAL} $(diskiomon_parameters)
 
-else 
+else
     declare -A diskio_data_rw
     while true; do
         for led in "${!devices[@]}"; do


### PR DESCRIPTION
## Problem

On systems where no SATA drives are installed in the physical bays (e.g.
NVMe-only or USB-only setups), `ugreen-diskiomon` fails with exit code 1.

Two issues compound to cause this:

1. **Bad array subscript** — when `MAPPING_METHOD=ata`, `disk_enumerating_string`
   parses `ls -ahl /sys/block` output. Non-SATA block devices (loop, NVMe, USB)
   produce lines without an `ata[0-9]+` match, leaving `blk_line[1]` empty.
   Bash rejects an empty string as an associative array key, crashing at the
   `dev_map[${key}]` assignment.

2. **Empty device list passed to sub-commands** — even after skipping bad keys,
   if no SATA drives are present `devices` remains empty. `ugreen-blink-disk`
   and `ugreen-check-standby` are then called with no `<block device> <led device>`
   pairs, causing them to print usage and exit with code 1, which fails the service.

## Fix

- Skip associative array assignment when `key` is empty (guard with
  `[[ -z "$key" ]] && continue`)
- After the LED initialization loop, exit with code 0 if `devices` is empty,
  logging a human-readable message

The disk LEDs are still correctly turned off via the existing per-slot
brightness/trigger reset before the early exit, so LED state is clean.

## Affected Hardware

Confirmed on UGREEN DXP2800 running Debian 13 (Trixie), kernel 6.12,
with no drives installed in SATA bays (NVMe system drive only).