### PR TITLE
Exit codes and systemd traps

### DIFF
--- a/scripts/ugreen-diskiomon
+++ b/scripts/ugreen-diskiomon
@@ -9,6 +9,7 @@ exit-ugreen-diskiomon() {
   [[ -n "$zpool_check_pid" ]] && kill $zpool_check_pid 2>/dev/null
   [[ -n "$disk_online_check_pid" ]] && kill $disk_online_check_pid 2>/dev/null
   [[ -n "$standby_checker_pid" ]] && kill $standby_checker_pid 2>/dev/null
+  exit 0
 }
 
 # check if script is already running
@@ -19,7 +20,7 @@ fi
 touch /var/run/ugreen-diskiomon.lock
 
 # trap exit and remove lockfile
-trap 'exit-ugreen-diskiomon' EXIT
+trap 'exit-ugreen-diskiomon' EXIT INT TERM
 
 # use variables from config file (unRAID specific)
 if [[ -f /boot/config/plugins/ugreenleds-driver/settings.cfg ]]; then

--- a/scripts/ugreen-netdevmon
+++ b/scripts/ugreen-netdevmon
@@ -5,10 +5,11 @@ exit-ugreen-netdevmon() {
   if [[ -f "/var/run/ugreen-netdevmon.lock" ]]; then
     rm "/var/run/ugreen-netdevmon.lock"
   fi
+  exit 0
 }
 
 # trap exit and remove lockfile
-trap 'exit-ugreen-netdevmon' EXIT
+trap 'exit-ugreen-netdevmon' EXIT INT TERM
 
 # check if script is already running
 if [[ -f "/var/run/ugreen-netdevmon.lock" ]]; then

--- a/scripts/ugreen-netdevmon-multi
+++ b/scripts/ugreen-netdevmon-multi
@@ -8,9 +8,10 @@ exit-ugreen-netdevmon-multi() {
     if [[ -f "/var/run/ugreen-netdevmon-multi.lock" ]]; then
         rm "/var/run/ugreen-netdevmon-multi.lock"
     fi
+    exit 0
 }
 
-trap 'exit-ugreen-netdevmon-multi' EXIT
+trap 'exit-ugreen-netdevmon-multi' EXIT INT TERM
 
 # Check if already running
 if [[ -f "/var/run/ugreen-netdevmon-multi.lock" ]]; then


### PR DESCRIPTION
When run under `systemd` control, we need to handle `SIGTERM` and `SIGINT` for cleanup in service scripts. Also, to avoid exiting with e.g. error code 143, in cleanup code, we need to exit cleanly.