### PR TITLE
Update action versions

### DIFF
--- a/.github/workflows/build-truenas.yml
+++ b/.github/workflows/build-truenas.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: gh-actions
 
@@ -27,7 +27,7 @@ jobs:
       run: bash build-all.sh
 
     - name: Push results to GitHub
-      uses: stefanzweifel/git-auto-commit-action@v5
+      uses: stefanzweifel/git-auto-commit-action@v7
       with:
         commit_message: "Add compiled modules"
         branch: gh-actions


### PR DESCRIPTION
Node 20 is outdated and actions based on it might stop working:

<img width="1382" height="867" alt="image" src="https://github.com/user-attachments/assets/2605a7d1-efd5-45f7-a7da-f31dbc611e6d" />

<br><br>

@miskcoo, you could consider adding dependabot to your repository for keeping used action versions in your workflow automatically updated and secure.