### PR TITLE
Build TrueNAS kmod from TrueNAS-SCALE-x.y.z.update image instead of Packages.gz

### DIFF
--- a/build-scripts/truenas/Dockerfile
+++ b/build-scripts/truenas/Dockerfile
@@ -11,6 +11,8 @@ RUN set -ex \
                fakeroot \
                wget \
                git \
+               gnupg \
+               squashfs-tools \
     && apt-get clean \
     && rm -rf /tmp/* /var/tmp/*
 

--- a/build-scripts/truenas/README.md
+++ b/build-scripts/truenas/README.md
@@ -1,14 +1,24 @@
+# Building the LED kernel module for TrueNAS SCALE
 
-Run `bash build.sh TrueNAS-SCALE-Dragonfish/24.04.1`
+Run:
 
-### Important Note
-When you find errors like this:
 ```
---2025-01-19 09:03:41-- https://download.truenas.com/TrueNAS-SCALE-ElectricEel/24.10.1/packages/Packages.gz
-Resolving download.truenas.com (download.truenas.com)... 185.244.226.2
-Connecting to download.truenas.com (download.truenas.com)|185.244.226.2|:443... connected.
-HTTP request sent, awaiting response... 404 Not Found
-2025-01-19 09:03:42 ERROR 404: Not Found.
+bash build.sh TrueNAS-SCALE-Goldeye/25.10.4
 ```
 
-You can try to use previous versions. See Issue #28.
+The argument is the version path as it appears under
+<https://download.truenas.com/>. The resulting `led-ugreen.ko` is written to
+`build/<version-path>/`.
+
+## How it works
+
+1. Download the TrueNAS-SCALE `.update` file (a GPG-signed squashfs image) and
+   its `.sig` for the requested version.
+2. Verify the signature against the iX SecTeam key, then extract the kernel
+   headers package from the image with `extract-truenas-headers.sh`.
+3. Build `led-ugreen.ko` against those headers inside a Debian container.
+
+The headers come from the `.update` image because the per-release
+`packages/Packages.gz` index that earlier builds relied on is not published for
+every version (e.g. it is missing for 25.10.4). An `.update` file, by contrast,
+is published for every release.

--- a/build-scripts/truenas/build-truenas-kmod.sh
+++ b/build-scripts/truenas/build-truenas-kmod.sh
@@ -1,22 +1,32 @@
 set -x
+set -euo pipefail
 
+# $1 is the TrueNAS version path, e.g. "TrueNAS-SCALE-Goldeye/25.10.4".
+version_path="$1"
+# Version number is the part after the slash, e.g. "25.10.4".
+version="${version_path##*/}"
 
-url_prefix="https://download.truenas.com/$1/packages/"
+url_prefix="https://download.truenas.com/${version_path}/"
+update_file="TrueNAS-SCALE-${version}.update"
 
 mkdir truenas_working
 cd truenas_working
 
-if ! wget "${url_prefix}Packages.gz"; then
+# Fetch the .update squashfs image (and its signature). It is published for
+# every release, including ones without a packages/Packages.gz index (e.g.
+# 25.10.4); the kernel headers are extracted from it below.
+if ! wget -nv "${url_prefix}${update_file}"; then
     cd ..
-    rm -rf truenas_working 
+    rm -rf truenas_working
     exit 0
 fi
+wget -nv "${url_prefix}${update_file}.sig"
 
-gzip -d Packages.gz
-deb_name=$(grep linux-headers-truenas-production Packages | grep -Po "(?<=Filename: ./).*deb")
-wget "${url_prefix}${deb_name}"
+# Build linux-headers-truenas-production-amd64.deb straight from the .update.
+bash /extract-truenas-headers.sh "${update_file}" .
+
 mkdir tmp
-dpkg-deb -R ${deb_name} tmp
+dpkg-deb -R linux-headers-truenas-production-amd64_*.deb tmp
 
 git clone https://github.com/miskcoo/ugreen_dx4600_leds_controller.git
 cd ugreen_dx4600_leds_controller/kmod
@@ -31,9 +41,9 @@ all:
 
 EOF
 
-make 
+make
 
 cd ../../../
-mkdir -p $1
-cp truenas_working/ugreen_dx4600_leds_controller/kmod/*.ko $1
+mkdir -p "$1"
+cp truenas_working/ugreen_dx4600_leds_controller/kmod/*.ko "$1"
 rm -fr truenas_working

--- a/build-scripts/truenas/build.sh
+++ b/build-scripts/truenas/build.sh
@@ -9,5 +9,6 @@ docker run \
     --rm \
     --mount type=bind,source=$(pwd)/build,target=/build \
     --mount type=bind,source=$(pwd)/build-truenas-kmod.sh,target=/build.sh \
+    --mount type=bind,source=$(pwd)/extract-truenas-headers.sh,target=/extract-truenas-headers.sh \
     bookworm-build \
     bash -c "cd /build && bash /build.sh $1"

--- a/build-scripts/truenas/extract-truenas-headers.sh
+++ b/build-scripts/truenas/extract-truenas-headers.sh
@@ -1,0 +1,245 @@
+#!/bin/bash
+#
+# extract-truenas-headers.sh
+#
+# Build linux-headers-truenas-production-amd64.deb directly from a TrueNAS-SCALE
+# update file (TrueNAS-SCALE-<ver>.update). No ISO handling required.
+#
+# Style: Google Shell Style Guide (2-space indent, main(), lower_case funcs).
+
+set -euo pipefail
+
+#######################################
+# Constants
+#######################################
+readonly PKG="linux-headers-truenas-production-amd64"
+# iX SecTeam <security-officer@ixsystems.com> - signs TrueNAS releases/updates.
+# Override only for testing:  IX_FPR=<fpr> ./extract-truenas-headers.sh ...
+readonly IX_FPR="${IX_FPR:-C8D62DEF767C1DB0DFF4E6EC358EAA9112CF7946}"
+
+# Scratch dir (global so the EXIT trap can reach it after main() returns).
+work_dir=""
+
+#######################################
+# Remove the scratch directory. Registered as the EXIT trap.
+#######################################
+cleanup() {
+  [[ -n "${work_dir}" ]] && rm -rf "${work_dir}"
+}
+
+#######################################
+# Print a message to stderr.
+#######################################
+err() {
+  echo "$@" >&2
+}
+
+#######################################
+# Print a message to stderr and exit non-zero.
+#######################################
+die() {
+  err "Error: $*"
+  exit 1
+}
+
+#######################################
+# Print usage and exit 0.
+#######################################
+usage() {
+  cat <<'USAGE'
+Usage:
+  extract-truenas-headers.sh [options] <TrueNAS-SCALE-x.y.z.update> [output-dir]
+
+Options:
+  --sig <file>   Signature file to use (default: <update>.sig if present)
+  --key <file>   Import the iX public key from a file instead of a keyserver
+  --no-verify    Skip signature verification (not recommended)
+  -h, --help     Show this help
+
+Signature verification:
+  Verifies the .update against the iX SecTeam key and ensures the primary
+  fingerprint exactly matches the pinned trust anchor. If the key is not in
+  the keyring it is fetched from a keyserver; when offline, supply it with
+  --key <pubkey.asc>. Show the fingerprint with:
+    gpg --fingerprint security-officer@ixsystems.com
+
+Notes:
+  unsquashfs needs ~2 GB of scratch space. If /tmp is too small, set TMPDIR:
+    TMPDIR=/mnt/pool/tmp extract-truenas-headers.sh ...
+USAGE
+  exit 0
+}
+
+#######################################
+# Verify that required commands exist.
+# Arguments:
+#   List of command names.
+#######################################
+require_tools() {
+  local tool
+  for tool in "$@"; do
+    command -v "${tool}" >/dev/null || die "'${tool}' not in PATH"
+  done
+}
+
+#######################################
+# Verify a detached signature against the pinned iX key.
+# Globals:
+#   IX_FPR (read)
+# Arguments:
+#   1: file that was signed
+#   2: detached signature file
+#   3: optional public-key file to import (may be empty)
+#######################################
+verify_signature() {
+  local file="$1"
+  local sig="$2"
+  local key_file="$3"
+
+  require_tools gpg
+
+  # Make sure the pinned key is available in the keyring.
+  if ! gpg --list-keys "${IX_FPR}" >/dev/null 2>&1; then
+    if [[ -n "${key_file}" ]]; then
+      gpg --import "${key_file}" >/dev/null 2>&1 \
+        || die "importing '${key_file}' failed"
+    else
+      err "    iX key not in keyring, trying keyserver..."
+      gpg --batch --keyserver hkps://keys.openpgp.org \
+        --keyserver-options timeout=15 \
+        --recv-keys "${IX_FPR}" >/dev/null 2>&1 || true
+    fi
+  fi
+  if ! gpg --list-keys "${IX_FPR}" >/dev/null 2>&1; then
+    err "Error: iX public key (${IX_FPR}) not available."
+    err "       Import with:  gpg --recv-keys ${IX_FPR}"
+    err "       or a file:    --key <pubkey.asc>   (or --no-verify)"
+    exit 1
+  fi
+
+  # Verify, then confirm the *primary* fingerprint matches the pin so that a
+  # valid signature from any other key cannot pass.
+  local status primary
+  status="$(LC_ALL=C gpg --status-fd 1 --verify "${sig}" "${file}" 2>/dev/null)" \
+    || die "signature verification FAILED for '${file}'"
+
+  primary="$(awk '/^\[GNUPG:\] VALIDSIG/ {print $NF}' <<<"${status}")"
+  if [[ "${primary}" != "${IX_FPR}" ]]; then
+    err "Error: signature is NOT from the expected iX key"
+    err "       expected: ${IX_FPR}"
+    err "       got:      ${primary:-<no valid signature>}"
+    exit 1
+  fi
+
+  echo "    Signature OK -> iX SecTeam (${IX_FPR})"
+}
+
+#######################################
+# Main
+#######################################
+main() {
+  local sig_file="" key_file="" no_verify=0
+  local -a posargs=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --sig)       sig_file="${2:?--sig requires a path}"; shift 2 ;;
+      --key)       key_file="${2:?--key requires a path}"; shift 2 ;;
+      --no-verify) no_verify=1; shift ;;
+      -h|--help)   usage ;;
+      --)          shift; while [[ $# -gt 0 ]]; do posargs+=("$1"); shift; done ;;
+      -*)          die "unknown option '$1'" ;;
+      *)           posargs+=("$1"); shift ;;
+    esac
+  done
+
+  local update_file="${posargs[0]:?Usage: $0 [options] <*.update file> [output-dir]}"
+  local output_dir="${posargs[1]:-.}"
+
+  [[ -f "${update_file}" ]] || die "'${update_file}' not found"
+
+  require_tools unsquashfs dpkg-deb awk
+
+  work_dir="$(mktemp -d "${TMPDIR:-/tmp}/truenas-headers.XXXXXX")"
+  trap cleanup EXIT
+
+  # ---- 0) signature verification ----------------------------------------
+  if (( no_verify )); then
+    echo "[0/4] Signature verification skipped (--no-verify)"
+  else
+    if [[ -z "${sig_file}" && -f "${update_file}.sig" ]]; then
+      sig_file="${update_file}.sig"
+    fi
+    [[ -n "${sig_file}" ]] \
+      || die "no signature found (${update_file}.sig missing); use --sig or --no-verify"
+    [[ -f "${sig_file}" ]] || die "signature '${sig_file}' not found"
+
+    echo "[0/4] Verifying signature (${sig_file})..."
+    verify_signature "${update_file}" "${sig_file}" "${key_file}"
+  fi
+
+  # ---- 1) pull rootfs.squashfs out of the .update -----------------------
+  echo "[1/4] Extracting rootfs.squashfs from the update file..."
+  unsquashfs -d "${work_dir}/outer" "${update_file}" rootfs.squashfs >/dev/null
+  local rootfs="${work_dir}/outer/rootfs.squashfs"
+  [[ -f "${rootfs}" ]] || die "rootfs.squashfs not found in the update file"
+
+  # ---- 2) package metadata ----------------------------------------------
+  echo "[2/4] Reading package metadata..."
+  unsquashfs -d "${work_dir}/dpkg" "${rootfs}" \
+    "var/lib/dpkg/status" \
+    "var/lib/dpkg/info/${PKG}.md5sums" >/dev/null
+
+  local status_file="${work_dir}/dpkg/var/lib/dpkg/status"
+  grep -q "^Package: ${PKG}\$" "${status_file}" \
+    || die "${PKG} not installed in rootfs"
+
+  local pkg_version
+  pkg_version="$(awk -v pkg="${PKG}" '
+    $0 == "Package: " pkg {f = 1}
+    f && /^$/                {exit}
+    f && /^Version:/         {print $2; exit}
+  ' "${status_file}")"
+  [[ -n "${pkg_version}" ]] || die "could not read Version"
+
+  # Kernel version = package version without the Debian revision suffix.
+  local kernel_version="${pkg_version%-*}"
+  echo "    Version: ${pkg_version}  (kernel ${kernel_version})"
+
+  # ---- 3) header tree + modules/build symlink ---------------------------
+  echo "[3/4] Extracting header files..."
+  unsquashfs -d "${work_dir}/files" "${rootfs}" \
+    "usr/src/${PKG}" \
+    "usr/share/doc/${PKG}" \
+    "usr/lib/modules/${kernel_version}/build" >/dev/null
+  [[ -d "${work_dir}/files/usr/src/${PKG}" ]] || die "header files missing"
+
+  rm -f "${rootfs}"  # free ~1.8 GB before packing
+
+  # ---- 4) build the .deb ------------------------------------------------
+  echo "[4/4] Building .deb..."
+  local deb_root="${work_dir}/deb"
+  mkdir -p "${deb_root}/DEBIAN"
+
+  # control = the full dpkg stanza minus dpkg-internal fields.
+  awk -v pkg="${PKG}" '
+    $0 == "Package: " pkg     {f = 1}
+    f && /^$/                  {exit}
+    f && /^Status:/            {next}
+    f && /^Config-Version:/    {next}
+    f                          {print}
+  ' "${status_file}" >"${deb_root}/DEBIAN/control"
+  [[ -s "${deb_root}/DEBIAN/control" ]] || die "empty control file"
+
+  cp "${work_dir}/dpkg/var/lib/dpkg/info/${PKG}.md5sums" \
+    "${deb_root}/DEBIAN/md5sums"
+  cp -a "${work_dir}/files/usr" "${deb_root}/"
+
+  mkdir -p "${output_dir}"
+  local deb_file="${output_dir}/${PKG}_${pkg_version}_amd64.deb"
+  dpkg-deb --build --root-owner-group "${deb_root}" "${deb_file}"
+
+  echo "Done -> ${deb_file} ($(du -sh "${deb_file}" | cut -f1))"
+}
+
+main "$@"


### PR DESCRIPTION
## Problem

The current led-ugreen.ko TrueNAS build fetches kernel headers from the per-release `packages/Packages.gz` index, but neither that index nor the packages are published for every version.
E.g. it's missing for 25.10.4 - so the build fails for those releases.

related Issues:

- https://github.com/miskcoo/ugreen_leds_controller/issues/96 
- https://github.com/miskcoo/ugreen_leds_controller/issues/13#issuecomment-4633238589
- https://github.com/0x556c79/install_ugreen_leds_controller/issues/22

## Change

Extract the headers from the GPG-signed `.update` squashfs image instead, which is published for every release.

- New `extract-truenas-headers.sh` downloads/unpacks the `TrueNAS-SCALE-x.y.z.update`'s rootfs, verifies the `.update` signature against the iX SecTeam key, and builds the `linux-headers-truenas-production-amd64.deb` from the embedded rootfs.
- `build-truenas-kmod.sh` now drives that script and builds `led-ugreen.ko` against the extracted headers; the `Packages.gz` download/parse path is gone.
- `Dockerfile` adds `gnupg` (signature verification) and `squashfs-tools` (`unsquashfs`).
- README updated to describe the `TrueNAS-SCALE-x.y.z.update`-based flow.

## Verification

Built for `TrueNAS-SCALE-Goldeye/25.10.2.1`, `TrueNAS-SCALE-Goldeye/25.10.0` and `TrueNAS-SCALE-Fangtooth/25.04.2.4` and I confirmed the resulting `led-ugreen.ko` is **byte-identical** to the ones produced by the old `Packages.gz` gh-action flow on this repository.

## Notes

- The current `Build kernel module for TrueNAS` workflow checks out the `gh-actions` branch, so these scripts also need to land on the branch `gh-actions` for the daily CI build to use them, this PR only updates `master`.
- `unsquashfs` needs temporarily ~2 GB of scratch space; on constrained `/tmp` set `TMPDIR`.
- Signatures are verified against the pinned iX SecTeam key fingerprint, and the build aborts if the `.update` signature doesn't match.
  
@miskcoo would be nice if you could review this pull request, and merge it into the `gh-actions` branch, so the people can use your kmod on the current TrueNAS version.
  
Thank you very much.