### PR TITLE
Enable health color per disk definitions via ugreen-leds.conf

### DIFF
--- a/scripts/check-standby.cpp
+++ b/scripts/check-standby.cpp
@@ -32,6 +32,21 @@ std::optional<bool> is_standby_mode(const std::string &device) {
     return args[2] == 0x00;
 }
 
+std::vector<std::string> split(const std::string& str, char delimiter) {
+    std::vector<std::string> tokens;
+    size_t start = 0;
+    size_t end = str.find(delimiter);
+
+    while (end != std::string::npos) {
+        tokens.push_back(str.substr(start, end - start));
+        start = end + 1;
+        end = str.find(delimiter, start);
+    }
+
+    tokens.push_back(str.substr(start));
+    return tokens;
+}
+
 int main(int argc, char *argv[]) {
 
     constexpr int preleading_args = 4;
@@ -49,11 +64,13 @@ int main(int argc, char *argv[]) {
     int checker_sleep_ms = int(std::stod(argv[1]) * 1000);
 
     std::string standby_color = argv[2];
-    std::string normal_color = argv[3];
+    std::string normal_colors_as_string = argv[3];
     std::vector<std::string> block_device_paths;
     std::vector<std::string> led_device_color_paths;
 
-    std::cout << normal_color;
+    std::cout << normal_colors_as_string;
+
+    std::vector<std::string> normal_colors = split(normal_colors_as_string, ',');
 
     for (int i = 0; i < num_devices; i++) {
         std::string block_device = argv[preleading_args + 2 * i];
@@ -94,6 +111,8 @@ int main(int argc, char *argv[]) {
 
                 std::string current_color;
                 std::getline(led_color, current_color);
+
+                std::string normal_color = normal_colors[i];
 
                 if (device_standby[i] && current_color == standby_color) {
                     led_color << normal_color << std::endl;

--- a/scripts/ugreen-diskiomon
+++ b/scripts/ugreen-diskiomon
@@ -114,7 +114,7 @@ BRIGHTNESS_DISK_LEDS=${BRIGHTNESS_DISK_LEDS:="255"}
 { lsmod | grep ledtrig_oneshot > /dev/null; } || { modprobe -v ledtrig_oneshot && sleep 2; }
 
 function is_disk_healthy_or_standby() {
-    if [[ "$1" == "$COLOR_DISK_HEALTH" || "$1" == "$COLOR_DISK_STANDBY" ]]; then
+    if [[ "$1" == "$2" || "$1" == "$COLOR_DISK_STANDBY" ]]; then
         return 0  # 0 means successful
     else
         return 1
@@ -140,6 +140,17 @@ function disk_enumerating_string() {
     fi
 }
 
+function color_disk_health() {
+    DISK=$1
+    COLOR=""
+    if [[ -v COLOR_DISK_HEALTH_PER_DISK[$DISK] ]]; then
+        COLOR=${COLOR_DISK_HEALTH_PER_DISK[${DISK}]}
+    else
+        COLOR=$COLOR_DISK_HEALTH
+    fi
+    echo $COLOR
+}
+
 echo Enumerating disks based on $MAPPING_METHOD...
 declare -A dev_map
 while read line
@@ -161,7 +172,8 @@ for i in "${!led_map[@]}"; do
         echo ${LED_INVERT:=1} > /sys/class/leds/$led/invert
         echo 100 > /sys/class/leds/$led/delay_on
         echo 100 > /sys/class/leds/$led/delay_off
-        echo "$COLOR_DISK_HEALTH" > /sys/class/leds/$led/color
+        color_health=$(color_disk_health "$led")
+        echo "$color_health" > /sys/class/leds/$led/color
         echo "$BRIGHTNESS_DISK_LEDS" > /sys/class/leds/$led/brightness
 
         # find corresponding device
@@ -239,8 +251,9 @@ if [ "$CHECK_ZPOOL" = true ]; then
                 if [[ -v "zpool_ledmap[${zpool_dev_name}]" ]]; then
                     led=${zpool_ledmap[$zpool_dev_name]}
                     led_color=$(cat /sys/class/leds/$led/color)
+                    color_health=$(color_disk_health "$led")
 
-                    if ! is_disk_healthy_or_standby "$led_color"; then
+                    if ! is_disk_healthy_or_standby "$led_color" "$color_health"; then
                         continue;
                     fi
 
@@ -252,7 +265,7 @@ if [ "$CHECK_ZPOOL" = true ]; then
                     # ==== To recover from an error, you should restart the script ====
                     ## case "${zpool_dev_state}" in
                     ##     ONLINE)
-                    ##         # echo "$COLOR_DISK_HEALTH" > /sys/class/leds/$led/color
+                    ##         # echo "$color_health" > /sys/class/leds/$led/color
                     ##         ;;
                     ##     *)
                     ##         echo "255 0 0" > /sys/class/leds/$led/color
@@ -276,7 +289,8 @@ if [ "$CHECK_SMART" = true ]; then
         for led in "${!devices[@]}"; do
 
             led_color=$(cat /sys/class/leds/$led/color)
-            if ! is_disk_healthy_or_standby "$led_color"; then
+            color_health=$(color_disk_health "$led")
+            if ! is_disk_healthy_or_standby "$led_color" "$color_health"; then
                 continue;
             fi
 
@@ -307,7 +321,8 @@ fi
             dev=${devices[$led]}
 
             led_color=$(cat /sys/class/leds/$led/color)
-            if ! is_disk_healthy_or_standby "$led_color"; then
+            color_health=$(color_disk_health "$led")
+            if ! is_disk_healthy_or_standby "$led_color" "$color_health"; then
                 continue;
             fi
 
@@ -323,6 +338,19 @@ fi
 disk_online_check_pid=$!
 
 
+function disk_health_parameters() {
+    disk_health_colors=""
+    for i in "${!led_map[@]}"; do
+        led=${led_map[i]}
+        if [[ -v devices[$led] ]]; then
+            color_health=$(color_disk_health "$led")
+            disk_health_colors="${disk_health_colors}$color_health,"
+        fi
+    done
+    disk_health_colors=${disk_health_colors%,}
+    echo $disk_health_colors
+}
+
 diskiomon_parameters() {
     for led in "${!devices[@]}"; do
         echo ${devices[$led]} $led
@@ -333,7 +361,7 @@ diskiomon_parameters() {
 STANDBY_MON_PATH=${STANDBY_MON_PATH:=/usr/bin/ugreen-check-standby}
 STANDBY_CHECK_INTERVAL=${STANDBY_CHECK_INTERVAL:=1}
 if [ -f "${STANDBY_MON_PATH}" ]; then
-    ${STANDBY_MON_PATH} ${STANDBY_CHECK_INTERVAL} "${COLOR_DISK_STANDBY}" "${COLOR_DISK_HEALTH}" $(diskiomon_parameters) &
+    ${STANDBY_MON_PATH} ${STANDBY_CHECK_INTERVAL} "${COLOR_DISK_STANDBY}" "$(disk_health_parameters)" $(diskiomon_parameters) &
     standby_checker_pid=$!
 fi
 

--- a/scripts/ugreen-leds.conf
+++ b/scripts/ugreen-leds.conf
@@ -53,6 +53,19 @@ BRIGHTNESS_DISK_LEDS="255"
 # color of a healthy disk (default: 255 255 255)
 COLOR_DISK_HEALTH="255 255 255"
 
+# color of a healthy disk assigned per disk (default: "255 255 255" for all disks)
+# If a disk to color mapping is missing then fallback to COLOR_DISK_HEALTH for the disk
+declare -A COLOR_DISK_HEALTH_PER_DISK
+
+COLOR_DISK_HEALTH_PER_DISK[disk1]="255 255 255"
+COLOR_DISK_HEALTH_PER_DISK[disk2]="255 255 255"
+COLOR_DISK_HEALTH_PER_DISK[disk3]="255 255 255"
+COLOR_DISK_HEALTH_PER_DISK[disk4]="255 255 255"
+COLOR_DISK_HEALTH_PER_DISK[disk5]="255 255 255"
+COLOR_DISK_HEALTH_PER_DISK[disk6]="255 255 255"
+COLOR_DISK_HEALTH_PER_DISK[disk7]="255 255 255"
+COLOR_DISK_HEALTH_PER_DISK[disk8]="255 255 255"
+
 # color of an unavailable disk (default: 255 0 0)
 COLOR_DISK_UNAVAIL="255 0 0"
 


### PR DESCRIPTION
The feature enables definition of health colors per disk. For example, one can define a specific color to a pair of RAID1 disks.