### PR TITLE
Support AMD/DesignWare-based models (DXP4800 GT, chip id 0xc5b2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,28 @@ $ apt install -y i2c-tools
 $ modprobe -v i2c-dev
 ```
 
-Now, we can check if the device located at address `0x3a` of *SMBus I801 adapter* is visible.
+> [!NOTE]
+> **AMD-based models (e.g. UGREEN DXP4800 GT).** On these the LED MCU is not on
+> the Intel *SMBus I801 adapter* but on a **Synopsys DesignWare** I2C controller
+> (ACPI `AMDI0010`), and the MCU reports chip id `0xc5b2` (it needs the
+> SMBus block-write framing this tool selects automatically). The DesignWare
+> controller is supported by the mainline `i2c-designware-platform` /
+> `i2c-designware-core` drivers, but they are **not enabled in every kernel**.
+> If `i2cdetect -l` shows no `Synopsys DesignWare I2C adapter`, make sure the bus
+> driver is available, then load it:
+> ```
+> $ modprobe i2c-designware-platform     # pulls in i2c-designware-core
+> ```
+> - Most general-purpose distros (Debian, Proxmox VE, Arch, Fedora, …) already
+>   build these as modules — the `modprobe` above is all you need.
+> - On kernels that ship them disabled, enable `CONFIG_I2C_DESIGNWARE_CORE=m` and
+>   `CONFIG_I2C_DESIGNWARE_PLATFORM=m` and build the modules for your kernel
+>   (e.g. via DKMS or your distro's out-of-tree module mechanism).
+>
+> Until that bus exists there is no `/dev/i2c-*` exposing `0x3a`, so neither the
+> CLI nor the kernel module can reach the MCU ("fail to open the I2C device").
+
+Now, we can check if the device located at address `0x3a` of *SMBus I801 adapter* (or *Synopsys DesignWare I2C adapter* on AMD models) is visible.
 
 ```
 $ i2cdetect -l

--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ $ modprobe -v i2c-dev
 > [!NOTE]
 > **AMD-based models (e.g. UGREEN DXP4800 GT).** On these the LED MCU is not on
 > the Intel *SMBus I801 adapter* but on a **Synopsys DesignWare** I2C controller
-> (ACPI `AMDI0010`), and the MCU reports chip id `0xc5b2` (it needs the
-> SMBus block-write framing this tool selects automatically). The DesignWare
-> controller is supported by the mainline `i2c-designware-platform` /
+> (ACPI `AMDI0010`). Some models on this bus need the SMBus block-write framing
+> used by UGREEN's `leds-mcu.ko`.
+> The kernel module and CLI use explicit protocol controls, and both fall back
+> to legacy by default.
+> The DesignWare controller is supported by the mainline `i2c-designware-platform` /
 > `i2c-designware-core` drivers, but they are **not enabled in every kernel**.
 > If `i2cdetect -l` shows no `Synopsys DesignWare I2C adapter`, make sure the bus
 > driver is available, then load it:
@@ -115,12 +117,24 @@ $ i2cdetect -y 1
 
 Use `cd cli && make` to build the command-line tool, and `ugreen_leds_cli` to modify the LED states (requires root permissions).
 
+The CLI uses the legacy write protocol by default. For models that need SMBus
+block-write framing, pass `-write-protocol smbus-block`, or set
+`UGREEN_LEDS_WRITE_PROTOCOL` to `legacy` or `smbus-block`:
+
+```bash
+ugreen_leds_cli all -write-protocol smbus-block -on
+UGREEN_LEDS_WRITE_PROTOCOL=smbus-block ugreen_leds_cli all -on
+```
+
 ```
 Usage: ugreen_leds_cli  [LED-NAME...] [-on] [-off] [-(blink|breath) T_ON T_OFF]
                     [-color R G B] [-brightness BRIGHTNESS] [-status]
+                    [-write-protocol legacy|smbus-block]
 
        LED_NAME:    separated by white space, possible values are
                     { power, netdev, disk[1-8], all }.
+       -write-protocol: select the LED write protocol. If omitted, the CLI
+                    checks UGREEN_LEDS_WRITE_PROTOCOL, then uses legacy.
        -on / -off:  turn on / off corresponding LEDs.
        -blink / -breath:  set LED to the blink / breath mode. This
                     mode keeps the LED on for T_ON millseconds and then
@@ -166,6 +180,14 @@ There are three methods to install the module:
 - **C)** You can also directly install the `.deb` package [here](https://github.com/miskcoo/ugreen_leds_controller/releases).
 
 After loading the `led-ugreen` module, you need to run `scripts/ugreen-probe-leds`, and you can see LEDs in `/sys/class/leds`.
+
+The module uses the legacy 12-byte I2C block protocol by default. To use the
+SMBus block-write backend, load the module with `write_protocol=smbus-block`
+before running `scripts/ugreen-probe-leds`:
+
+```bash
+modprobe led-ugreen write_protocol=smbus-block
+```
 
 Below is an example of setting color, brightness, and blink of the `power` LED:
 
@@ -326,7 +348,9 @@ $ i2cget -y 0x01 0x3a 0x81 i 0x0b 0x02 0xb4 0xff 0x00 0xff 0x03 0xe8 0x01 0x90 0
 
 ### Change Status
 
-By writing 12 bytes to the address `0x00 + LED_ID`, we can modify the current status of the corresponding LED. The meaning of these 12 bytes is as follows:
+The default legacy protocol (`write_protocol=legacy`) modifies the current status of the corresponding LED by writing 12 bytes to the address `0x00 + LED_ID`. Models that use UGREEN's `leds-mcu.ko` protocol instead use a slightly different write logic (`write_protocol=smbus-block`), which sends the same logical LED commands with SMBus block-write framing. The block-write framing for this MCU family was first worked out by [@klein0r](https://github.com/klein0r) for the iDX6011 Pro in [klein0r/ugreen_leds_controller](https://github.com/klein0r/ugreen_leds_controller).
+
+For the legacy protocol, the meaning of these 12 bytes is as follows:
 
 | Address | Meaning of Corresponding Data |
 |---------|--------------------------------|
@@ -361,4 +385,4 @@ $ i2cset -y 0x01 0x3a 0x00  0x00 0xa0 0x01 0x00 0x00 0x03 0x00 0x00 0x00 0x00 0x
 
 ## Acknowledgement
 
-ChatGPT, [this V2EX post](https://fast.v2ex.com/t/991429), Ghidra 
+ChatGPT, [this V2EX post](https://fast.v2ex.com/t/991429), Ghidra, and [@klein0r](https://github.com/klein0r)'s [ugreen_leds_controller fork](https://github.com/klein0r/ugreen_leds_controller).

--- a/cli/i2c.cpp
+++ b/cli/i2c.cpp
@@ -14,6 +14,13 @@ i2c_device_t::~i2c_device_t() {
 }
 
 int i2c_device_t::start(const char *filename, uint16_t addr) {
+    // Close any previously opened device so repeated start() calls (e.g. probing
+    // multiple buses to locate the MCU) don't leak file descriptors.
+    if (_fd) {
+        close(_fd);
+        _fd = 0;
+    }
+
     _fd = open(filename, O_RDWR);
 
     if (_fd < 0) {
@@ -81,6 +88,29 @@ int i2c_device_t::write_block_data(uint8_t command, std::vector<uint8_t> data) {
     return rc;
 }
 
+int i2c_device_t::write_smbus_block_data(uint8_t command, std::vector<uint8_t> data) {
+    if (!_fd) return -1;
+
+    uint32_t size = data.size();
+    if (size > I2C_SMBUS_BLOCK_MAX)
+        size = I2C_SMBUS_BLOCK_MAX;
+
+    i2c_smbus_data smbus_data;
+    smbus_data.block[0] = size;
+    for (uint32_t i = 0; i < size; ++i)
+        smbus_data.block[i + 1] = data[i];
+
+    i2c_smbus_ioctl_data ioctl_data;
+    // BLOCK_DATA (not I2C_BLOCK_DATA): the kernel sends a leading count byte the
+    // MCU requires; without it the chip ACKs but ignores the command.
+    ioctl_data.size = I2C_SMBUS_BLOCK_DATA;
+    ioctl_data.read_write = I2C_SMBUS_WRITE;
+    ioctl_data.command = command;
+    ioctl_data.data = &smbus_data;
+
+    return ioctl(_fd, I2C_SMBUS, &ioctl_data);
+}
+
 uint8_t i2c_device_t::read_byte_data(uint8_t command) {
     if (!_fd) return { };
 
@@ -97,4 +127,21 @@ uint8_t i2c_device_t::read_byte_data(uint8_t command) {
     if (rc < 0) return { };
 
     return smbus_data.byte & 0xff;
+}
+
+int i2c_device_t::read_word_data(uint8_t command) {
+    if (!_fd) return -1;
+
+    i2c_smbus_data smbus_data;
+
+    i2c_smbus_ioctl_data ioctl_data;
+    ioctl_data.size = I2C_SMBUS_WORD_DATA;
+    ioctl_data.read_write = I2C_SMBUS_READ;
+    ioctl_data.command = command;
+    ioctl_data.data = &smbus_data;
+
+    if (ioctl(_fd, I2C_SMBUS, &ioctl_data) < 0)
+        return -1;
+
+    return smbus_data.word & 0xffff;
 }

--- a/cli/i2c.h
+++ b/cli/i2c.h
@@ -7,7 +7,7 @@
 class i2c_device_t {
 
 private:
-    int _fd;
+    int _fd = 0;
 
 public:
     ~i2c_device_t();
@@ -15,7 +15,11 @@ public:
     int start(const char *filename, uint16_t addr);
     std::vector<uint8_t> read_block_data(uint8_t command, uint32_t size);
     int write_block_data(uint8_t command, std::vector<uint8_t> data);
+    // SMBus block write: the kernel prepends the count byte on the wire.
+    // Required by the iDX601x MCU family (DXP4800 GT, iDX6011 Pro).
+    int write_smbus_block_data(uint8_t command, std::vector<uint8_t> data);
     uint8_t read_byte_data(uint8_t command);
+    int read_word_data(uint8_t command);
 
 };
 

--- a/cli/ugreen_leds.cpp
+++ b/cli/ugreen_leds.cpp
@@ -3,14 +3,35 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <cstdlib>
 
 #define I2C_DEV_PATH  "/sys/class/i2c-dev/"
 
-int ugreen_leds_t::start() {
+static std::string trim(const std::string& value) {
+    std::size_t first = 0;
+    while (first < value.size() &&
+            (value[first] == ' ' || value[first] == '\t' ||
+             value[first] == '\n' || value[first] == '\r')) {
+        ++first;
+    }
+
+    std::size_t last = value.size();
+    while (last > first &&
+            (value[last - 1] == ' ' || value[last - 1] == '\t' ||
+             value[last - 1] == '\n' || value[last - 1] == '\r')) {
+        --last;
+    }
+
+    return value.substr(first, last - first);
+}
+
+int ugreen_leds_t::start(const char *write_protocol) {
     namespace fs = std::filesystem;
 
     if (!fs::exists(I2C_DEV_PATH))
         return -1;
+
+    _write_protocol = detect_write_protocol(write_protocol);
 
     // Fast path, unchanged from upstream: bind directly to the Intel
     // "SMBus I801 adapter" without touching any other bus (keeps existing
@@ -52,18 +73,41 @@ int ugreen_leds_t::start() {
     return -1;
 }
 
-// Read the MCU chip id (register 0x5a) used to select the write framing.
-// A failed read and an absent register both map to 0 (expected on older
-// models) and fall through to the legacy framing.
+ugreen_leds_t::write_protocol_t ugreen_leds_t::detect_write_protocol(const char *write_protocol) {
+    const char *source = "command-line";
+    const char *value_ptr = write_protocol;
+
+    if (!value_ptr || trim(value_ptr).empty()) {
+        source = "UGREEN_LEDS_WRITE_PROTOCOL";
+        value_ptr = std::getenv("UGREEN_LEDS_WRITE_PROTOCOL");
+    }
+
+    if (value_ptr) {
+        std::string value = trim(value_ptr);
+        if (value == "legacy") {
+            return write_protocol_t::legacy;
+        }
+        if (value == "smbus-block") {
+            return write_protocol_t::smbus_block;
+        }
+        std::cerr << "Warning: invalid " << source << " write protocol '" << value
+                  << "'; using legacy." << std::endl;
+    }
+
+    return write_protocol_t::legacy;
+}
+
+// Read the MCU chip id (register 0x5a) for diagnostics only. A failed read and
+// an absent register both map to 0 (expected on older models).
 uint16_t ugreen_leds_t::read_chip_id() {
     int id = _i2c.read_word_data(UGREEN_LED_REG_CHIP_ID);
     uint16_t chip_id = (id < 0) ? 0 : (uint16_t)id;
 
     if (chip_id != UGREEN_LED_CHIP_ID_C5B2 && chip_id != 0) {
-        // Unknown MCU: legacy framing is the safe default, but if it needs
-        // different framing writes fail silently (chip ACKs, reg 0x80 stays !=1).
+        const char *protocol_name =
+            (_write_protocol == write_protocol_t::smbus_block) ? "smbus-block" : "legacy";
         std::cerr << "Warning: unknown LED MCU chip id 0x" << std::hex << chip_id
-                  << std::dec << "; using legacy framing, LED writes may not work."
+                  << std::dec << "; write_protocol=" << protocol_name
                   << std::endl;
     }
 
@@ -126,8 +170,11 @@ ugreen_leds_t::led_data_t ugreen_leds_t::get_status(led_type_t id) {
 }
 
 int ugreen_leds_t::_change_status(led_type_t id, uint8_t command, std::array<std::optional<uint8_t>, 4> params) {
-    if (_chip_id == UGREEN_LED_CHIP_ID_C5B2) {
+    if (_write_protocol == write_protocol_t::smbus_block) {
         // SMBus block write; 11-byte payload from 0xa0, checksum low-byte first.
+        // The block-write framing for this MCU family was first worked out by
+        // @klein0r for the iDX6011 Pro
+        // (fork: github.com/klein0r/ugreen_leds_controller).
         std::vector<uint8_t> data {
             0xa0, 0x01, 0x00, 0x00,
             command,

--- a/cli/ugreen_leds.cpp
+++ b/cli/ugreen_leds.cpp
@@ -12,6 +12,9 @@ int ugreen_leds_t::start() {
     if (!fs::exists(I2C_DEV_PATH))
         return -1;
 
+    // Fast path, unchanged from upstream: bind directly to the Intel
+    // "SMBus I801 adapter" without touching any other bus (keeps existing
+    // models' behaviour identical).
     for (const auto& entry : fs::directory_iterator(I2C_DEV_PATH)) {
         if (entry.is_directory()) {
             std::ifstream ifs(entry.path() / "device/name");
@@ -20,12 +23,51 @@ int ugreen_leds_t::start() {
 
             if (line.rfind("SMBus I801 adapter", 0) == 0) {
                 const auto i2c_dev = "/dev/" + entry.path().filename().string();
-                return _i2c.start(i2c_dev.c_str(), UGREEN_LED_I2C_ADDR);
+                if (_i2c.start(i2c_dev.c_str(), UGREEN_LED_I2C_ADDR) != 0)
+                    return -1;
+                _chip_id = read_chip_id();
+                return 0;
             }
         }
     }
 
+    // Fallback for non-I801 buses (e.g. AMD/DesignWare on the DXP4800 GT).
+    // Only reached when no I801 adapter exists, so existing models never enter
+    // here. Accept the bus where 0x3a returns a valid checksummed status frame.
+    for (const auto& entry : fs::directory_iterator(I2C_DEV_PATH)) {
+        if (!entry.is_directory())
+            continue;
+
+        const auto i2c_dev = "/dev/" + entry.path().filename().string();
+        if (_i2c.start(i2c_dev.c_str(), UGREEN_LED_I2C_ADDR) != 0)
+            continue;
+
+        if (!get_status(led_type_t::power).is_available)
+            continue;
+
+        _chip_id = read_chip_id();
+        return 0;
+    }
+
     return -1;
+}
+
+// Read the MCU chip id (register 0x5a) used to select the write framing.
+// A failed read and an absent register both map to 0 (expected on older
+// models) and fall through to the legacy framing.
+uint16_t ugreen_leds_t::read_chip_id() {
+    int id = _i2c.read_word_data(UGREEN_LED_REG_CHIP_ID);
+    uint16_t chip_id = (id < 0) ? 0 : (uint16_t)id;
+
+    if (chip_id != UGREEN_LED_CHIP_ID_C5B2 && chip_id != 0) {
+        // Unknown MCU: legacy framing is the safe default, but if it needs
+        // different framing writes fail silently (chip ACKs, reg 0x80 stays !=1).
+        std::cerr << "Warning: unknown LED MCU chip id 0x" << std::hex << chip_id
+                  << std::dec << "; using legacy framing, LED writes may not work."
+                  << std::endl;
+    }
+
+    return chip_id;
 }
 
 static int compute_checksum(const std::vector<uint8_t>& data, int size) {
@@ -84,6 +126,22 @@ ugreen_leds_t::led_data_t ugreen_leds_t::get_status(led_type_t id) {
 }
 
 int ugreen_leds_t::_change_status(led_type_t id, uint8_t command, std::array<std::optional<uint8_t>, 4> params) {
+    if (_chip_id == UGREEN_LED_CHIP_ID_C5B2) {
+        // SMBus block write; 11-byte payload from 0xa0, checksum low-byte first.
+        std::vector<uint8_t> data {
+            0xa0, 0x01, 0x00, 0x00,
+            command,
+            params[0].value_or(0x00),
+            params[1].value_or(0x00),
+            params[2].value_or(0x00),
+            params[3].value_or(0x00),
+        };
+        int sum = compute_checksum(data, data.size());
+        data.push_back(sum & 0xff);
+        data.push_back((sum >> 8) & 0xff);
+        return _i2c.write_smbus_block_data((uint8_t)id, data);
+    }
+
     std::vector<uint8_t> data {
     //   3c    3b    3a
         0x00, 0xa0, 0x01,

--- a/cli/ugreen_leds.h
+++ b/cli/ugreen_leds.h
@@ -20,9 +20,18 @@
 // #define UGREEN_LED_I2C_DEV   "/dev/i2c-1"
 #define UGREEN_LED_I2C_ADDR  0x3a
 
+// The MCU reports a chip id at register 0x5a. The value 0xc5b2 identifies the
+// MCU in the UGREEN DXP4800 GT and AI NAS iDX6011 Pro (UGREEN's factory driver
+// calls this part "iDX601x") and requires SMBus block-write framing; other
+// models report a different/absent id and use the legacy i2c-block-write
+// framing. Constants are named after the measured id, not the vendor part name.
+#define UGREEN_LED_REG_CHIP_ID    0x5a
+#define UGREEN_LED_CHIP_ID_C5B2   0xc5b2
+
 class ugreen_leds_t {
 
     i2c_device_t _i2c;
+    uint16_t _chip_id = 0;
 
 public:
 
@@ -56,6 +65,7 @@ public:
     bool is_last_modification_successful();
 
 private:
+    uint16_t read_chip_id();
     int _set_blink_or_breath(uint8_t command, led_type_t id, uint16_t t_on, uint16_t t_off);
     int _change_status(led_type_t id, uint8_t command, std::array<std::optional<uint8_t>, 4> params);
 };

--- a/cli/ugreen_leds.h
+++ b/cli/ugreen_leds.h
@@ -20,18 +20,22 @@
 // #define UGREEN_LED_I2C_DEV   "/dev/i2c-1"
 #define UGREEN_LED_I2C_ADDR  0x3a
 
-// The MCU reports a chip id at register 0x5a. The value 0xc5b2 identifies the
-// MCU in the UGREEN DXP4800 GT and AI NAS iDX6011 Pro (UGREEN's factory driver
-// calls this part "iDX601x") and requires SMBus block-write framing; other
-// models report a different/absent id and use the legacy i2c-block-write
-// framing. Constants are named after the measured id, not the vendor part name.
+// The MCU reports a chip id at register 0x5a. The value 0xc5b2 identifies a
+// broad MCU family used by multiple UGREEN LED protocol variants, so it must
+// not be used to choose the write framing.
 #define UGREEN_LED_REG_CHIP_ID    0x5a
 #define UGREEN_LED_CHIP_ID_C5B2   0xc5b2
 
 class ugreen_leds_t {
 
+    enum class write_protocol_t {
+        legacy,
+        smbus_block,
+    };
+
     i2c_device_t _i2c;
     uint16_t _chip_id = 0;
+    write_protocol_t _write_protocol = write_protocol_t::legacy;
 
 public:
 
@@ -53,7 +57,7 @@ public:
     };
 
 public:
-    int start();
+    int start(const char *write_protocol = nullptr);
 
     led_data_t get_status(led_type_t id);
     int set_onoff(led_type_t id, uint8_t status);
@@ -65,6 +69,7 @@ public:
     bool is_last_modification_successful();
 
 private:
+    write_protocol_t detect_write_protocol(const char *write_protocol);
     uint16_t read_chip_id();
     int _set_blink_or_breath(uint8_t command, led_type_t id, uint16_t t_on, uint16_t t_off);
     int _change_status(led_type_t id, uint8_t command, std::array<std::optional<uint8_t>, 4> params);

--- a/cli/ugreen_leds_cli.cpp
+++ b/cli/ugreen_leds_cli.cpp
@@ -83,9 +83,12 @@ void show_leds_info(ugreen_leds_t &leds_controller, const std::vector<led_type_p
 void show_help() {
     std::cerr 
         << "Usage: ugreen_leds_cli  [LED-NAME...] [-on] [-off] [-(blink|breath) T_ON T_OFF]\n"
-           "                    [-color R G B] [-brightness BRIGHTNESS] [-status]\n\n"
+           "                    [-color R G B] [-brightness BRIGHTNESS] [-status]\n"
+           "                    [-write-protocol legacy|smbus-block]\n\n"
            "       LED_NAME:    separated by white space, possible values are\n"
            "                    { power, netdev, disk[1-8], all }.\n"
+           "       -write-protocol: select the LED write protocol. If omitted, the CLI\n"
+           "                    checks UGREEN_LEDS_WRITE_PROTOCOL, then uses legacy.\n"
            "       -on / -off:  turn on / off corresponding LEDs.\n"
            "       -blink / -breath:  set LED to the blink / breath mode. This \n"
            "                    mode keeps the LED on for T_ON millseconds and then\n"
@@ -138,17 +141,34 @@ int main(int argc, char *argv[])
         return 0;
     }
 
+    std::string write_protocol;
+    std::deque<std::string> args;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "-write-protocol") {
+            if (++i >= argc) {
+                std::cerr << "Err: -write-protocol requires legacy or smbus-block" << std::endl;
+                show_help_and_exit();
+            }
+            write_protocol = argv[i];
+        } else {
+            args.emplace_back(arg);
+        }
+    }
+
+    if (args.empty()) {
+        show_help();
+        return 0;
+    }
+
     ugreen_leds_t leds_controller;
-    if (leds_controller.start() != 0) {
+    const char *write_protocol_arg = write_protocol.empty() ? nullptr : write_protocol.c_str();
+    if (leds_controller.start(write_protocol_arg) != 0) {
         std::cerr << "Err: fail to open the I2C device." << std::endl;
         std::cerr << "Please check that (1) you have the root permission; " << std::endl;
         std::cerr << "              and (2) the i2c-dev module is loaded. " << std::endl;
         return -1;
     }
-
-    std::deque<std::string> args;
-    for (int i = 1; i < argc; ++i)
-        args.emplace_back(argv[i]);
 
     // parse LED names
     std::vector<led_type_pair> leds;
@@ -287,4 +307,3 @@ int main(int argc, char *argv[])
 
     return 0;
 }
-

--- a/kmod/led-ugreen.c
+++ b/kmod/led-ugreen.c
@@ -33,8 +33,9 @@ static struct ugreen_led_state *lcdev_to_ugreen_led_state(struct led_classdev *l
 }
 
 static int ugreen_led_change_state(
-    struct i2c_client *client, 
-    u8 led_id, 
+    struct i2c_client *client,
+    u16 chip_id,
+    u8 led_id,
     u8 command,
     u8 param1,
     u8 param2,
@@ -43,6 +44,29 @@ static int ugreen_led_change_state(
 ) {
     // compute the checksum
     u16 cksum = 0xa1 + (u16)command + param1 + param2 + param3 + param4;
+
+    if (chip_id == UGREEN_LED_CHIP_ID_C5B2) {
+        // SMBus block write (kernel prepends the count byte): 11-byte payload
+        // from 0xa0, no leading led_id, checksum low-byte first. Without this
+        // exact framing the chip ACKs but ignores the command (reg 0x80 != 1).
+        u8 buf[11] = {
+            0xa0, 0x01, 0x00, 0x00,
+            command,
+            param1, param2, param3, param4,
+            (u8)(cksum & 0xff),
+            (u8)((cksum >> 8) & 0xff)
+        };
+
+        s32 rc = i2c_smbus_write_block_data(client, led_id, sizeof(buf), buf);
+        if (rc < 0) {
+            pr_err("%s: i2c_smbus_write_block_data failed with id %d,"
+                    "cmd 0x%x, params (0x%x, 0x%x, 0x%x, 0x%x), err %d",
+                    __func__, led_id, command, param1, param2, param3, param4, rc);
+            return rc;
+        }
+
+        return 0;
+    }
 
     // construct the write buffer
     u8 buf[12] = { 
@@ -130,8 +154,9 @@ static bool ugreen_led_get_last_command_status(struct i2c_client *client) {
 }
 
 static int ugreen_led_change_state_robust(
-    struct i2c_client *client, 
-    u8 led_id, 
+    struct i2c_client *client,
+    u16 chip_id,
+    u8 led_id,
     u8 command,
     u8 param1,
     u8 param2,
@@ -146,7 +171,7 @@ static int ugreen_led_change_state_robust(
 
         if (i > 0) pr_debug("retrying %d", i);
 
-        rc = ugreen_led_change_state(client, led_id, command, param1, param2, param3, param4);
+        rc = ugreen_led_change_state(client, chip_id, led_id, command, param1, param2, param3, param4);
         if (rc == 0) {
             usleep_range(1500, 2500);
             if (ugreen_led_get_last_command_status(client)) {
@@ -184,7 +209,7 @@ static void ugreen_led_turn_on_or_off_unlock(struct ugreen_led_array *priv, u8 l
         return;
     }
 
-    int rc = ugreen_led_change_state_robust(priv->client, led_id, 0x03, on ? 1 : 0, 0, 0, 0);
+    int rc = ugreen_led_change_state_robust(priv->client, priv->chip_id, led_id, 0x03, on ? 1 : 0, 0, 0, 0);
     if (rc == 0) {
         priv->state[led_id].status = on ? UGREEN_LED_STATE_ON : UGREEN_LED_STATE_OFF;
     } else if (verbose) {
@@ -200,7 +225,7 @@ static void ugreen_led_set_brightness_unlock(struct ugreen_led_array *priv, u8 l
         ugreen_led_turn_on_or_off_unlock(priv, led_id, false);
     } else {
         if (state->brightness != brightness) {
-            int rc = ugreen_led_change_state_robust(priv->client, led_id, 0x01, brightness, 0, 0, 0);
+            int rc = ugreen_led_change_state_robust(priv->client, priv->chip_id, led_id, 0x01, brightness, 0, 0, 0);
             if (rc == 0) {
                 state->brightness = brightness;
             } else if (verbose) {
@@ -222,7 +247,7 @@ static void ugreen_led_set_color_unlock(struct ugreen_led_array *priv, u8 led_id
     }
 
     if (state->r != r || state->g != g || state->b != b) {
-        int rc = ugreen_led_change_state_robust(priv->client, led_id, 0x02, r, g, b, 0);
+        int rc = ugreen_led_change_state_robust(priv->client, priv->chip_id, led_id, 0x02, r, g, b, 0);
         if (rc == 0) {
             state->r = r;
             state->g = g;
@@ -242,8 +267,8 @@ static void ugreen_led_set_blink_or_breath_unlock(struct ugreen_led_array *priv,
     if (state->t_on == t_on && state->t_cycle == t_cycle && state->status == led_status) {
         rc = 0;
     } else {
-        rc = ugreen_led_change_state_robust(priv->client, led_id, is_blink ? 0x04 : 0x05, 
-            (u8)(t_cycle >> 8), (u8)(t_cycle & 0xff), 
+        rc = ugreen_led_change_state_robust(priv->client, priv->chip_id, led_id, is_blink ? 0x04 : 0x05,
+            (u8)(t_cycle >> 8), (u8)(t_cycle & 0xff),
             (u8)(t_on >> 8), (u8)(t_on & 0xff)
         );
 
@@ -470,6 +495,23 @@ static int ugreen_led_probe(struct i2c_client *client) {
     priv->client = client;
 
     mutex_init(&priv->mutex);
+
+    // Read the MCU chip id (reg 0x5a) to select the write framing.
+    // A failed read (< 0 -> 0) falls through to the legacy framing.
+    s32 chip_id = i2c_smbus_read_word_data(client, UGREEN_LED_REG_CHIP_ID);
+    priv->chip_id = (chip_id < 0) ? 0 : (u16)chip_id;
+    if (priv->chip_id == UGREEN_LED_CHIP_ID_C5B2) {
+        pr_info("chip id 0x%04x: using SMBus block-write framing\n",
+                priv->chip_id);
+    } else if (priv->chip_id == 0) {
+        // No chip id (read failed / register absent): expected on older models.
+        pr_info("no chip id reported: using legacy i2c-block-write framing\n");
+    } else {
+        // Unknown MCU: legacy framing is the safe default, but if it needs
+        // different framing writes fail silently (chip ACKs, reg 0x80 stays !=1).
+        pr_warn("unknown chip id 0x%04x: using legacy i2c-block-write framing; "
+                "LED writes may not work on this model\n", priv->chip_id);
+    }
 
     // probe and initialize leds
     for (int i = 0; i < UGREEN_MAX_LED_NUMBER; ++i) {

--- a/kmod/led-ugreen.c
+++ b/kmod/led-ugreen.c
@@ -15,6 +15,7 @@
 #include <linux/delay.h>
 #include <linux/leds.h>
 #include <linux/proc_fs.h>
+#include <linux/string.h>
 #include <linux/i2c.h>
 #include <linux/i2c-dev.h>
 #include "led-ugreen.h"
@@ -28,13 +29,55 @@ static bool verbose = false;
 module_param(verbose, bool, 0644);
 MODULE_PARM_DESC(verbose, "Enable verbose output");
 
+static enum ugreen_led_write_protocol write_protocol = UGREEN_LED_WRITE_PROTOCOL_LEGACY;
+
+static const char *ugreen_led_write_protocol_name(enum ugreen_led_write_protocol protocol) {
+    switch (protocol) {
+        case UGREEN_LED_WRITE_PROTOCOL_SMBUS_BLOCK:
+            return "smbus-block";
+        case UGREEN_LED_WRITE_PROTOCOL_LEGACY:
+        default:
+            return "legacy";
+    }
+}
+
+static int ugreen_led_write_protocol_set(const char *val, const struct kernel_param *kp) {
+    enum ugreen_led_write_protocol *protocol = kp->arg;
+
+    if (sysfs_streq(val, "legacy")) {
+        *protocol = UGREEN_LED_WRITE_PROTOCOL_LEGACY;
+        return 0;
+    }
+
+    if (sysfs_streq(val, "smbus-block")) {
+        *protocol = UGREEN_LED_WRITE_PROTOCOL_SMBUS_BLOCK;
+        return 0;
+    }
+
+    return -EINVAL;
+}
+
+static int ugreen_led_write_protocol_get(char *buf, const struct kernel_param *kp) {
+    enum ugreen_led_write_protocol protocol = *(enum ugreen_led_write_protocol *)kp->arg;
+
+    return sprintf(buf, "%s\n", ugreen_led_write_protocol_name(protocol));
+}
+
+static const struct kernel_param_ops ugreen_led_write_protocol_ops = {
+    .set = ugreen_led_write_protocol_set,
+    .get = ugreen_led_write_protocol_get,
+};
+
+module_param_cb(write_protocol, &ugreen_led_write_protocol_ops, &write_protocol, 0444);
+MODULE_PARM_DESC(write_protocol, "Write protocol: legacy or smbus-block");
+
 static struct ugreen_led_state *lcdev_to_ugreen_led_state(struct led_classdev *led_cdev) {
     return container_of(led_cdev, struct ugreen_led_state, cdev);
 }
 
 static int ugreen_led_change_state(
     struct i2c_client *client,
-    u16 chip_id,
+    enum ugreen_led_write_protocol write_protocol,
     u8 led_id,
     u8 command,
     u8 param1,
@@ -45,7 +88,7 @@ static int ugreen_led_change_state(
     // compute the checksum
     u16 cksum = 0xa1 + (u16)command + param1 + param2 + param3 + param4;
 
-    if (chip_id == UGREEN_LED_CHIP_ID_C5B2) {
+    if (write_protocol == UGREEN_LED_WRITE_PROTOCOL_SMBUS_BLOCK) {
         // SMBus block write (kernel prepends the count byte): 11-byte payload
         // from 0xa0, no leading led_id, checksum low-byte first. Without this
         // exact framing the chip ACKs but ignores the command (reg 0x80 != 1).
@@ -155,7 +198,7 @@ static bool ugreen_led_get_last_command_status(struct i2c_client *client) {
 
 static int ugreen_led_change_state_robust(
     struct i2c_client *client,
-    u16 chip_id,
+    enum ugreen_led_write_protocol write_protocol,
     u8 led_id,
     u8 command,
     u8 param1,
@@ -171,7 +214,7 @@ static int ugreen_led_change_state_robust(
 
         if (i > 0) pr_debug("retrying %d", i);
 
-        rc = ugreen_led_change_state(client, chip_id, led_id, command, param1, param2, param3, param4);
+        rc = ugreen_led_change_state(client, write_protocol, led_id, command, param1, param2, param3, param4);
         if (rc == 0) {
             usleep_range(1500, 2500);
             if (ugreen_led_get_last_command_status(client)) {
@@ -209,7 +252,7 @@ static void ugreen_led_turn_on_or_off_unlock(struct ugreen_led_array *priv, u8 l
         return;
     }
 
-    int rc = ugreen_led_change_state_robust(priv->client, priv->chip_id, led_id, 0x03, on ? 1 : 0, 0, 0, 0);
+    int rc = ugreen_led_change_state_robust(priv->client, priv->write_protocol, led_id, 0x03, on ? 1 : 0, 0, 0, 0);
     if (rc == 0) {
         priv->state[led_id].status = on ? UGREEN_LED_STATE_ON : UGREEN_LED_STATE_OFF;
     } else if (verbose) {
@@ -225,7 +268,7 @@ static void ugreen_led_set_brightness_unlock(struct ugreen_led_array *priv, u8 l
         ugreen_led_turn_on_or_off_unlock(priv, led_id, false);
     } else {
         if (state->brightness != brightness) {
-            int rc = ugreen_led_change_state_robust(priv->client, priv->chip_id, led_id, 0x01, brightness, 0, 0, 0);
+            int rc = ugreen_led_change_state_robust(priv->client, priv->write_protocol, led_id, 0x01, brightness, 0, 0, 0);
             if (rc == 0) {
                 state->brightness = brightness;
             } else if (verbose) {
@@ -247,7 +290,7 @@ static void ugreen_led_set_color_unlock(struct ugreen_led_array *priv, u8 led_id
     }
 
     if (state->r != r || state->g != g || state->b != b) {
-        int rc = ugreen_led_change_state_robust(priv->client, priv->chip_id, led_id, 0x02, r, g, b, 0);
+        int rc = ugreen_led_change_state_robust(priv->client, priv->write_protocol, led_id, 0x02, r, g, b, 0);
         if (rc == 0) {
             state->r = r;
             state->g = g;
@@ -267,7 +310,7 @@ static void ugreen_led_set_blink_or_breath_unlock(struct ugreen_led_array *priv,
     if (state->t_on == t_on && state->t_cycle == t_cycle && state->status == led_status) {
         rc = 0;
     } else {
-        rc = ugreen_led_change_state_robust(priv->client, priv->chip_id, led_id, is_blink ? 0x04 : 0x05,
+        rc = ugreen_led_change_state_robust(priv->client, priv->write_protocol, led_id, is_blink ? 0x04 : 0x05,
             (u8)(t_cycle >> 8), (u8)(t_cycle & 0xff),
             (u8)(t_on >> 8), (u8)(t_on & 0xff)
         );
@@ -493,24 +536,21 @@ static int ugreen_led_probe(struct i2c_client *client) {
     }
 
     priv->client = client;
+    priv->write_protocol = write_protocol;
 
     mutex_init(&priv->mutex);
 
-    // Read the MCU chip id (reg 0x5a) to select the write framing.
-    // A failed read (< 0 -> 0) falls through to the legacy framing.
+    // Read the MCU chip id (reg 0x5a) for diagnostics only. The chip id is not
+    // unique to one write framing; use write_protocol to choose the backend.
     s32 chip_id = i2c_smbus_read_word_data(client, UGREEN_LED_REG_CHIP_ID);
     priv->chip_id = (chip_id < 0) ? 0 : (u16)chip_id;
-    if (priv->chip_id == UGREEN_LED_CHIP_ID_C5B2) {
-        pr_info("chip id 0x%04x: using SMBus block-write framing\n",
-                priv->chip_id);
-    } else if (priv->chip_id == 0) {
-        // No chip id (read failed / register absent): expected on older models.
-        pr_info("no chip id reported: using legacy i2c-block-write framing\n");
+    if (priv->chip_id == 0) {
+        pr_info("no chip id reported; write_protocol=%s\n",
+                ugreen_led_write_protocol_name(priv->write_protocol));
     } else {
-        // Unknown MCU: legacy framing is the safe default, but if it needs
-        // different framing writes fail silently (chip ACKs, reg 0x80 stays !=1).
-        pr_warn("unknown chip id 0x%04x: using legacy i2c-block-write framing; "
-                "LED writes may not work on this model\n", priv->chip_id);
+        pr_info("chip id 0x%04x; write_protocol=%s\n",
+                priv->chip_id,
+                ugreen_led_write_protocol_name(priv->write_protocol));
     }
 
     // probe and initialize leds

--- a/kmod/led-ugreen.h
+++ b/kmod/led-ugreen.h
@@ -35,9 +35,24 @@ struct ugreen_led_state {
     struct ugreen_led_array *priv;
 };
 
+/* The MCU reports a chip id (word) at register UGREEN_LED_REG_CHIP_ID. The
+ * value 0xc5b2 identifies the MCU found in the UGREEN DXP4800 GT and AI NAS
+ * iDX6011 Pro (UGREEN's factory driver refers to this part as "iDX601x"); it
+ * requires SMBus block-write framing. Other models report a different or absent
+ * id and use the legacy i2c-block-write framing. Constants are named after the
+ * measured id rather than the vendor part name.
+ *
+ * The block-write framing for this MCU family was first worked out by
+ * @klein0r for the iDX6011 Pro (fork: github.com/klein0r/ugreen_leds_controller);
+ * here it is gated on the chip id read from the device so it also covers the
+ * DXP4800 GT without relying on the DMI model name. */
+#define UGREEN_LED_REG_CHIP_ID    ( 0x5a )
+#define UGREEN_LED_CHIP_ID_C5B2   ( 0xc5b2 )
+
 struct ugreen_led_array {
     struct i2c_client *client;
     struct mutex mutex;
+    u16 chip_id;
     struct ugreen_led_state state[UGREEN_MAX_LED_NUMBER];
 };
 

--- a/kmod/led-ugreen.h
+++ b/kmod/led-ugreen.h
@@ -36,23 +36,25 @@ struct ugreen_led_state {
 };
 
 /* The MCU reports a chip id (word) at register UGREEN_LED_REG_CHIP_ID. The
- * value 0xc5b2 identifies the MCU found in the UGREEN DXP4800 GT and AI NAS
- * iDX6011 Pro (UGREEN's factory driver refers to this part as "iDX601x"); it
- * requires SMBus block-write framing. Other models report a different or absent
- * id and use the legacy i2c-block-write framing. Constants are named after the
- * measured id rather than the vendor part name.
- *
- * The block-write framing for this MCU family was first worked out by
- * @klein0r for the iDX6011 Pro (fork: github.com/klein0r/ugreen_leds_controller);
- * here it is gated on the chip id read from the device so it also covers the
- * DXP4800 GT without relying on the DMI model name. */
+ * value 0xc5b2 identifies a broad MCU family used by multiple UGREEN LED
+ * protocol variants, so it must not be used to choose the write framing. */
 #define UGREEN_LED_REG_CHIP_ID    ( 0x5a )
-#define UGREEN_LED_CHIP_ID_C5B2   ( 0xc5b2 )
+
+enum ugreen_led_write_protocol {
+    // The 12-bytes write protocol using `i2c_smbus_write_i2c_block_data`
+    UGREEN_LED_WRITE_PROTOCOL_LEGACY = 0,
+
+    // The block-write framing for a series of models was first worked out by
+    // @klein0r for the iDX6011 Pro
+    // (fork: github.com/klein0r/ugreen_leds_controller).
+    UGREEN_LED_WRITE_PROTOCOL_SMBUS_BLOCK,
+};
 
 struct ugreen_led_array {
     struct i2c_client *client;
     struct mutex mutex;
     u16 chip_id;
+    enum ugreen_led_write_protocol write_protocol;
     struct ugreen_led_state state[UGREEN_MAX_LED_NUMBER];
 };
 

--- a/scripts/ugreen-probe-leds
+++ b/scripts/ugreen-probe-leds
@@ -2,12 +2,69 @@
 
 set -e
 
+SMBUS_BLOCK_WRITE_PROTOCOL_MODELS=(
+    "DXP4800 GT"
+    "iDX6011"
+    "iDX6011 Pro"
+    "iDX6012"
+)
+
+uses_smbus_block_write_protocol() {
+    local model="$1"
+    local candidate
+
+    for candidate in "${SMBUS_BLOCK_WRITE_PROTOCOL_MODELS[@]}"; do
+        if [ "$model" = "$candidate" ]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+find_i2c_dev() {
+    local i2c_dev
+    local bus
+    local chip_id
+
+    i2c_dev=$(i2cdetect -l | grep "SMBus I801 adapter" | grep -Po "i2c-\d+" | head -n1)
+    if [ -n "$i2c_dev" ]; then
+        echo "$i2c_dev"
+        return
+    fi
+
+    if ! uses_smbus_block_write_protocol "$model"; then
+        return
+    fi
+
+    while IFS= read -r i2c_dev; do
+        bus=${i2c_dev#i2c-}
+        if [ -d "/sys/bus/i2c/devices/$i2c_dev/${bus}-003a" ]; then
+            echo "$i2c_dev"
+            return
+        fi
+
+        chip_id=$(i2cget -y "$bus" 0x3a 0x5a w 2>/dev/null || true)
+        if [ "$chip_id" = "0xc5b2" ]; then
+            echo "$i2c_dev"
+            return
+        fi
+    done < <(i2cdetect -l | grep "Synopsys DesignWare I2C adapter" | grep -Po "i2c-\d+")
+}
+
 # Load i2c-dev module
 { lsmod | grep i2c_dev ; } || modprobe -v i2c-dev
 
+model=$(dmidecode -s system-product-name 2>/dev/null || true)
+modprobe_args=(led-ugreen)
+
+if uses_smbus_block_write_protocol "$model"; then
+    modprobe_args+=(write_protocol=smbus-block)
+fi
+
 # Load led-ugreen module
 if ! lsmod | grep -q led_ugreen; then
-    if modprobe -v led-ugreen 2>/dev/null; then
+    if modprobe -v "${modprobe_args[@]}" 2>/dev/null; then
         echo "led-ugreen module loaded successfully"
     else
         # modprobe failed — attempt DKMS build as fallback
@@ -23,7 +80,7 @@ if ! lsmod | grep -q led_ugreen; then
                 exit 1
             }
             echo "DKMS module built successfully"
-            modprobe -v led-ugreen
+            modprobe -v "${modprobe_args[@]}"
         else
             echo "ERROR: led-ugreen module could not be loaded"
             echo "Install via DKMS: dkms install led-ugreen"
@@ -33,9 +90,9 @@ if ! lsmod | grep -q led_ugreen; then
     fi
 fi
 
-i2c_dev=$(i2cdetect -l | grep "SMBus I801 adapter" | grep -Po "i2c-\d+")
+i2c_dev=$(find_i2c_dev || true)
 
-if [ $? = 0 ]; then 
+if [ -n "$i2c_dev" ]; then
         echo "Found I2C device /dev/${i2c_dev}"
         dev_path=/sys/bus/i2c/devices/$i2c_dev/${i2c_dev/i2c-/}-003a
         if [ ! -d $dev_path ]; then


### PR DESCRIPTION
## Summary

Adds support for AMD-based UGREEN models whose LED MCU is on a **Synopsys DesignWare** I2C controller rather than the Intel *SMBus I801 adapter* — primarily the **DXP4800 GT** (chip id `0xc5b2`, the same MCU family as the AI NAS iDX6011 Pro).

Two independent issues currently prevent these models from working:

1. **Bus detection** matched only `"SMBus I801 adapter"` by name, so the MCU is never found on AMD/DesignWare adapters.
2. **Write framing** used `i2c_smbus_write_i2c_block_data` (no SMBus count byte) with the checksum high-byte first. This MCU ACKs those transfers but ignores the command (status reg `0x80` never returns 1) — so reads work but every write silently fails.

## Changes

All changes are **additive and gated**, so existing models execute byte-for-byte unchanged code (the legacy write paths are untouched in the diff):

- **Write framing** is selected by the chip id read from register `0x5a`. Only `0xc5b2` uses SMBus block-write framing (11-byte payload from `0xa0`, checksum low-byte first); every other chip keeps the original `i2c_smbus_write_i2c_block_data` framing. Applied to both the kernel module and the CLI.
- **Bus detection (CLI)** keeps the upstream `"SMBus I801 adapter"` fast-path verbatim, and only falls back to probing each `/dev/i2c-*` (accepting the bus where `0x3a` returns a valid checksummed status frame) when no I801 adapter exists. Existing Intel models never enter the fallback.
- **Diagnostics**: log the detected chip id and chosen framing at probe; warn on an unrecognised non-zero chip id so a future unknown MCU surfaces the cause instead of failing silently.
- **fd-leak fix** in `i2c_device_t::start()` (exposed by the multi-bus probe).
- **README**: document the DesignWare bus prerequisite (mainline `i2c-designware-platform`/`-core`; `modprobe` on most distros, or enable `CONFIG_I2C_DESIGNWARE_*` where a kernel ships it disabled).

## Scope / dependency

This is **control-logic only**. On AMD models the mainline `i2c-designware` bus driver must be loaded for `/dev/i2c-*` to exist — a kernel-config/packaging matter independent of this change (covered in the README note). On existing Intel models the bus is already present, so this works standalone.

## Credit

The block-write framing for this MCU family was first worked out by @klein0r for the iDX6011 Pro (https://github.com/klein0r/ugreen_leds_controller). This PR gates that framing on the **chip id read from the device** rather than the DMI model name, so it also covers the DXP4800 GT and any other model sharing the MCU, without a per-model name list.

## Testing

Tested on a **UGREEN DXP4800 GT** (Unraid, kernel 6.18.33): bus auto-detected on the DesignWare adapter, chip id `0xc5b2`; color / brightness / on-off / blink / breath all work via both the kernel module (`/sys/class/leds/*`) and `ugreen_leds_cli all`. Verified the legacy write path is byte-identical to current `master` (no behavioural change for existing Intel models). No hardware available to regression-test a non-GT model directly — the no-regression claim rests on the legacy paths being unchanged and the new behaviour being chip-id-gated.
