### PR TITLE
README: List newer devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,17 @@ This repository
 For the process of understanding this control logic, please refer to [my blog (in Chinese)](https://blog.miskcoo.com/2024/05/ugreen-dx4600-pro-led-controller).
 
 > [!NOTE]  
-> Only tested on the following devices:
+> Only tested and working on the following devices:
 > - [x] UGREEN DX4600 Pro
 > - [x] UGREEN DX4700+
 > - [x] UGREEN DXP2800 (reported in [#19](https://github.com/miskcoo/ugreen_leds_controller/issues/19))
 > - [x] UGREEN DXP4800 (confirmed in [#41](https://github.com/miskcoo/ugreen_leds_controller/issues/41))
 > - [x] UGREEN DXP4800 Plus (reported [here](https://gist.github.com/Kerryliu/c380bb6b3b69be5671105fc23e19b7e8))
+> - [ ] UGREEN DXP4800 GT ([#100](https://github.com/miskcoo/ugreen_leds_controller/pull/100))
 > - [x] UGREEN DXP6800 Pro (reported in [#7](https://github.com/miskcoo/ugreen_leds_controller/issues/7))
 > - [x] UGREEN DXP8800 Plus (see [this repo](https://github.com/meyergru/ugreen_dxp8800_leds_controller) and [#1](https://github.com/miskcoo/ugreen_leds_controller/issues/1))
 > - [ ] UGREEN DXP480T Plus (**Not yet**, but the protocol has been understood, see [#6](https://github.com/miskcoo/ugreen_leds_controller/issues/6#issuecomment-2156807225))
+> - [ ] UGREEN iDX6011 Pro ([#93](https://github.com/miskcoo/ugreen_leds_controller/issues/93))
 >
 >**I am not sure whether this is compatible with other devices.  
 >If you have tested it with different devices, please feel free to update the list above!**


### PR DESCRIPTION
Adding DXP4600 GT and iDX6011 Pro to the list as not yet supported.