### PR TITLE
Add iDX6011 Pro LED layout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,34 +179,31 @@ There are three methods to install the module:
 
 - **C)** You can also directly install the `.deb` package [here](https://github.com/miskcoo/ugreen_leds_controller/releases).
 
-After loading the `led-ugreen` module, you need to run `scripts/ugreen-probe-leds`, and you can see LEDs in `/sys/class/leds`.
+Run `scripts/ugreen-probe-leds` after installing the module.
+The script loads `led-ugreen` with the correct options for known models, binds the I2C device, and then LEDs appear in `/sys/class/leds`.
 
-The module uses the legacy 12-byte I2C block protocol by default. To use the
-SMBus block-write backend, load the module with `write_protocol=smbus-block`
-before running `scripts/ugreen-probe-leds`:
+The module uses the legacy 12-byte I2C block protocol by default.
+Models that need the SMBus block-write backend can load the module manually with `write_protocol=smbus-block`:
 
 ```bash
 modprobe led-ugreen write_protocol=smbus-block
 ```
 
-By default, the module auto-detects available LEDs and uses the legacy layout
-`power,netdev,disk1,disk2,...`. If your model has more than one network LED or
-you want to limit how many disk LEDs are exposed, use the `num_netdev_leds` and
-`num_disk_leds` module parameters. For example, the UGREEN iDX6011 Pro has two
-network LEDs followed by six disk LEDs:
+By default, the module auto-detects available LEDs and uses the legacy layout `power,netdev,disk1,disk2,...`.
+If your model has more than one network LED or you want to limit how many disk LEDs are exposed, use the `num_netdev_leds` and `num_disk_leds` module parameters.
+`scripts/ugreen-probe-leds` passes these automatically for known models.
+For example, the UGREEN iDX6011 Pro has two network LEDs followed by six disk LEDs, equivalent to:
 
 ```bash
 modprobe led-ugreen write_protocol=smbus-block num_netdev_leds=2 num_disk_leds=6
 ```
 
-If omitted, `num_netdev_leds` defaults to `1` and `num_disk_leds` defaults to
-the remaining LED IDs in the default 10-ID probe. Each count can be from `0` to
-`9`. LED names are assigned by physical ID: `0` is `power`, the next network
-LEDs are `netdev`, `netdev2`, `netdev3`, and so on, and the remaining LEDs are
-`disk1`, `disk2`, etc. The driver still probes only up to the configured layout
-size and skips IDs that do not report a valid LED state.
+If omitted, `num_netdev_leds` defaults to `1` and `num_disk_leds` defaults to the remaining LED IDs in the default 10-ID probe.
+Each count can be from `0` to `9`.
+LED names are assigned by physical ID: `0` is `power`, the next network LEDs are `netdev`, `netdev2`, `netdev3`, and so on, and the remaining LEDs are `disk1`, `disk2`, etc.
+The driver still probes only up to the configured layout size and skips IDs that do not report a valid LED state.
 
-For persistent module options, put them in `/etc/modprobe.d/led-ugreen.conf`:
+If you load `led-ugreen` outside `scripts/ugreen-probe-leds`, put persistent module options in `/etc/modprobe.d/led-ugreen.conf`:
 
 ```bash
 options led-ugreen write_protocol=smbus-block num_netdev_leds=2 num_disk_leds=6
@@ -245,11 +242,13 @@ Please see `scripts/ugreen-leds.conf` for an example.
   ```
   cat > /etc/modules-load.d/ugreen-led.conf << EOF
   i2c-dev
-  led-ugreen
   ledtrig-oneshot
   ledtrig-netdev
   EOF
   ```
+
+  Do not preload `led-ugreen` here.
+  `ugreen-probe-leds` loads it with model-specific options, such as the iDX6011 Pro LED layout.
 
 - Install the `smartctl` tool: `apt install smartmontools`
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,29 @@ before running `scripts/ugreen-probe-leds`:
 modprobe led-ugreen write_protocol=smbus-block
 ```
 
+By default, the module auto-detects available LEDs and uses the legacy layout
+`power,netdev,disk1,disk2,...`. If your model has more than one network LED or
+you want to limit how many disk LEDs are exposed, use the `num_netdev_leds` and
+`num_disk_leds` module parameters. For example, the UGREEN iDX6011 Pro has two
+network LEDs followed by six disk LEDs:
+
+```bash
+modprobe led-ugreen write_protocol=smbus-block num_netdev_leds=2 num_disk_leds=6
+```
+
+If omitted, `num_netdev_leds` defaults to `1` and `num_disk_leds` defaults to
+the remaining LED IDs in the default 10-ID probe. Each count can be from `0` to
+`9`. LED names are assigned by physical ID: `0` is `power`, the next network
+LEDs are `netdev`, `netdev2`, `netdev3`, and so on, and the remaining LEDs are
+`disk1`, `disk2`, etc. The driver still probes only up to the configured layout
+size and skips IDs that do not report a valid LED state.
+
+For persistent module options, put them in `/etc/modprobe.d/led-ugreen.conf`:
+
+```bash
+options led-ugreen write_protocol=smbus-block num_netdev_leds=2 num_disk_leds=6
+```
+
 Below is an example of setting color, brightness, and blink of the `power` LED:
 
 ```bash
@@ -319,6 +342,11 @@ The IDs for the LED lights on the front panel of the NAS chassis are as follows:
 | `0`         | Power indicator |
 | `1`         | Network device indicator |
 | `2`,`3`,... | Hard drive indicator "disk1", "disk2" etc. |
+
+These are the default names used by the kernel module. `num_netdev_leds` changes
+how many LEDs after `power` use network names (`netdev`, `netdev2`, ...);
+remaining probed LEDs use disk names (`disk1`, `disk2`, ...). `num_disk_leds`
+can limit how many disk LED IDs are probed.
 
 ### Query Status
 

--- a/kmod/debian/led-ugreen-dkms.postinst
+++ b/kmod/debian/led-ugreen-dkms.postinst
@@ -6,13 +6,12 @@ if [ "$1" = "configure" ]; then
     cat > /etc/modules-load.d/led-ugreen.conf << 'EOFINNER'
 # UGREEN LED driver modules
 i2c-dev
-led-ugreen
 ledtrig-oneshot
 ledtrig-netdev
 EOFINNER
 
     echo "UGREEN LED kernel module configured for autoload."
-    echo "Module will load automatically on next boot, or run: modprobe led-ugreen"
+    echo "The ugreen-probe-leds service will load led-ugreen with model-specific options."
 fi
 
 #DEBHELPER#

--- a/kmod/led-ugreen.c
+++ b/kmod/led-ugreen.c
@@ -71,6 +71,26 @@ static const struct kernel_param_ops ugreen_led_write_protocol_ops = {
 module_param_cb(write_protocol, &ugreen_led_write_protocol_ops, &write_protocol, 0444);
 MODULE_PARM_DESC(write_protocol, "Write protocol: legacy or smbus-block");
 
+#define UGREEN_LED_COUNT_UNSPECIFIED    ( -1 )
+
+static int num_netdev_leds = UGREEN_LED_COUNT_UNSPECIFIED;
+module_param(num_netdev_leds, int, 0444);
+MODULE_PARM_DESC(num_netdev_leds, "Number of network LEDs; default is 1");
+
+static int num_disk_leds = UGREEN_LED_COUNT_UNSPECIFIED;
+module_param(num_disk_leds, int, 0444);
+MODULE_PARM_DESC(num_disk_leds, "Number of disk LEDs; default is remaining LEDs in the default probe");
+
+static const char * const ugreen_led_netdev_names[] = {
+    "netdev", "netdev2", "netdev3", "netdev4", "netdev5",
+    "netdev6", "netdev7", "netdev8", "netdev9"
+};
+
+static const char * const ugreen_led_disk_names[] = {
+    "disk1", "disk2", "disk3", "disk4", "disk5",
+    "disk6", "disk7", "disk8", "disk9"
+};
+
 static struct ugreen_led_state *lcdev_to_ugreen_led_state(struct led_classdev *led_cdev) {
     return container_of(led_cdev, struct ugreen_led_state, cdev);
 }
@@ -553,11 +573,37 @@ static int ugreen_led_probe(struct i2c_client *client) {
                 ugreen_led_write_protocol_name(priv->write_protocol));
     }
 
-    // probe and initialize leds
-    for (int i = 0; i < UGREEN_MAX_LED_NUMBER; ++i) {
+    if (num_netdev_leds < UGREEN_LED_COUNT_UNSPECIFIED ||
+            num_netdev_leds > UGREEN_MAX_NETDEV_LED_COUNT) {
+        dev_err(&client->dev, "invalid num_netdev_leds %d\n", num_netdev_leds);
+        mutex_destroy(&priv->mutex);
+        return -EINVAL;
+    }
 
+    if (num_disk_leds < UGREEN_LED_COUNT_UNSPECIFIED ||
+            num_disk_leds > UGREEN_MAX_DISK_LED_COUNT) {
+        dev_err(&client->dev, "invalid num_disk_leds %d\n", num_disk_leds);
+        mutex_destroy(&priv->mutex);
+        return -EINVAL;
+    }
+
+    // probe and initialize leds
+    int netdev_count = num_netdev_leds == UGREEN_LED_COUNT_UNSPECIFIED ?
+        UGREEN_DEFAULT_NETDEV_LED_COUNT : num_netdev_leds;
+    int default_disk_count = UGREEN_DEFAULT_PROBE_LED_COUNT - UGREEN_POWER_LED_COUNT - netdev_count;
+    if (default_disk_count < 0)
+        default_disk_count = 0;
+    int disk_count = num_disk_leds == UGREEN_LED_COUNT_UNSPECIFIED ?
+        default_disk_count : num_disk_leds;
+    int probe_limit = UGREEN_POWER_LED_COUNT + netdev_count + disk_count;
+
+    for (int i = 0; i < UGREEN_MAX_LED_NUMBER; ++i) {
+        priv->state[i].status = UGREEN_LED_STATE_INVALID;
         priv->state[i].priv = priv;
         priv->state[i].led_id = i;
+    }
+
+    for (int i = 0; i < probe_limit; ++i) {
 
         ugreen_led_get_state_robust(client, i, priv->state + i);
 
@@ -565,7 +611,7 @@ static int ugreen_led_probe(struct i2c_client *client) {
         if (state->status != UGREEN_LED_STATE_INVALID) {
 
             pr_info("probed led id %d, status %d, rgb 0x%02x%02x%02x, "
-                    "brightness %d, t_on %d, t_cycle %d\n", i, 
+                    "brightness %d, t_on %d, t_cycle %d\n", i,
                     state->status, state->r, state->g, state->b,
                     state->brightness, state->t_on, state->t_cycle);
 
@@ -579,21 +625,19 @@ static int ugreen_led_probe(struct i2c_client *client) {
 
     mutex_lock(&priv->mutex);
 
-    // register leds class devices
-    const char *led_name[] = {
-        "power", "netdev", "disk1", "disk2", "disk3", "disk4", "disk5", "disk6", "disk7", "disk8"
-    };
-
-    for (int i = 0; i < UGREEN_MAX_LED_NUMBER; ++i) {
+    for (int i = 0; i < probe_limit; ++i) {
 
         struct ugreen_led_state *state = priv->state + i;
         if (state->status == UGREEN_LED_STATE_INVALID)
             continue;
 
-        // register the brightness control
-        if (i < ARRAY_SIZE(led_name))
-            state->cdev.name = led_name[i];
-        else state->cdev.name = "unknown";
+        if (i == 0) {
+            state->cdev.name = "power";
+        } else if (i <= netdev_count) {
+            state->cdev.name = ugreen_led_netdev_names[i - 1];
+        } else {
+            state->cdev.name = ugreen_led_disk_names[i - netdev_count - 1];
+        }
 
         state->cdev.brightness = state->cdev.brightness;
         state->cdev.max_brightness = 0xff;
@@ -602,9 +646,9 @@ static int ugreen_led_probe(struct i2c_client *client) {
         state->cdev.groups = ugreen_led_groups;
         state->cdev.blink_set = ugreen_led_set_blink;
 
-        if (i == 1) {
+        if (i > 0 && i <= netdev_count) {
             state->cdev.default_trigger = "netdev";
-        } else if (i >= 2) {
+        } else if (i > netdev_count) {
             state->cdev.default_trigger = "oneshot";
         }
 

--- a/kmod/led-ugreen.h
+++ b/kmod/led-ugreen.h
@@ -11,7 +11,13 @@
 #define UGREEN_LED_SLAVE_ADDR       ( 0x3a )
 #define UGREEN_LED_SLAVE_NAME       ( "led-ugreen" )
 
-#define UGREEN_MAX_LED_NUMBER           ( 10 )
+#define UGREEN_POWER_LED_COUNT              ( 1 )
+#define UGREEN_DEFAULT_NETDEV_LED_COUNT     ( 1 )
+#define UGREEN_DEFAULT_PROBE_LED_COUNT      ( 10 )
+#define UGREEN_MAX_NETDEV_LED_COUNT         ( 9 )
+#define UGREEN_MAX_DISK_LED_COUNT           ( 9 )
+#define UGREEN_MAX_LED_NUMBER               \
+    ( UGREEN_POWER_LED_COUNT + UGREEN_MAX_NETDEV_LED_COUNT + UGREEN_MAX_DISK_LED_COUNT )
 #define UGREEN_LED_CHANGE_STATE_RETRY_COUNT   ( 5 )
 
 #define UGREEN_LED_STATE_OFF        ( 0 )

--- a/scripts/ugreen-probe-leds
+++ b/scripts/ugreen-probe-leds
@@ -22,6 +22,20 @@ uses_smbus_block_write_protocol() {
     return 1
 }
 
+append_model_led_layout_options() {
+    local model="$1"
+
+    case "$model" in
+        "iDX6011 Pro")
+            modprobe_args+=(num_netdev_leds=2 num_disk_leds=6)
+            ;;
+    esac
+}
+
+led_ugreen_loaded() {
+    lsmod | grep -q "^led_ugreen[[:space:]]"
+}
+
 find_i2c_dev() {
     local i2c_dev
     local bus
@@ -61,9 +75,10 @@ modprobe_args=(led-ugreen)
 if uses_smbus_block_write_protocol "$model"; then
     modprobe_args+=(write_protocol=smbus-block)
 fi
+append_model_led_layout_options "$model"
 
 # Load led-ugreen module
-if ! lsmod | grep -q led_ugreen; then
+if ! led_ugreen_loaded; then
     if modprobe -v "${modprobe_args[@]}" 2>/dev/null; then
         echo "led-ugreen module loaded successfully"
     else
@@ -95,10 +110,10 @@ i2c_dev=$(find_i2c_dev || true)
 if [ -n "$i2c_dev" ]; then
         echo "Found I2C device /dev/${i2c_dev}"
         dev_path=/sys/bus/i2c/devices/$i2c_dev/${i2c_dev/i2c-/}-003a
-        if [ ! -d $dev_path ]; then
-            echo "led-ugreen 0x3a" > /sys/bus/i2c/devices/${i2c_dev}/new_device
-        elif [ "$(cat $dev_path/name)" != "led-ugreen" ]; then
-            echo "ERROR: the device ${i2c_dev/i2c-/}-003a has been registered as $(cat $dev_path/name)"
+        if [ ! -d "$dev_path" ]; then
+            echo "led-ugreen 0x3a" > "/sys/bus/i2c/devices/${i2c_dev}/new_device"
+        elif [ "$(cat "$dev_path/name")" != "led-ugreen" ]; then
+            echo "ERROR: the device ${i2c_dev/i2c-/}-003a has been registered as $(cat "$dev_path/name")"
             exit 1
         fi
 else


### PR DESCRIPTION
 ## Summary

  - Add configurable network and disk LED counts to the `led-ugreen` kernel module.
  - Configure `ugreen-probe-leds` to load `led-ugreen` with the iDX6011 Pro layout: `num_netdev_leds=2 num_disk_leds=6`.
  - Update README and DKMS post-install behavior so `led-ugreen` is loaded by the probe script with model-specific
  options instead of being preloaded with defaults.

  ## Why

  The iDX6011 Pro has two network LEDs followed by six disk LEDs. The previous default layout exposed only one network
  LED and assigned the remaining LEDs as disks, so the sysfs LED names did not match the physical layout.

  Module parameters must be supplied when `led-ugreen` is loaded. Letting `ugreen-probe-leds` load the module avoids
  boot-time autoloading with incorrect defaults.

--

Compatible to my DX4600 Pro. But not tested on iDX6011 Pro (i dont have it).