### PR TITLE
Remove LED invert write from netdevmon-multi script

### DIFF
--- a/scripts/ugreen-netdevmon-multi
+++ b/scripts/ugreen-netdevmon-multi
@@ -54,7 +54,6 @@ if [[ -d /sys/class/leds/$led ]]; then
     echo $NETDEV_BLINK_TX > /sys/class/leds/$led/tx
     echo $NETDEV_BLINK_RX > /sys/class/leds/$led/rx
     echo $NETDEV_BLINK_INTERVAL > /sys/class/leds/$led/interval
-    echo ${LED_INVERT:=1} > /sys/class/leds/$led/invert
     echo "$COLOR_NETDEV_NORMAL" > /sys/class/leds/$led/color
     echo $BRIGHTNESS_NETDEV_LED > /sys/class/leds/$led/brightness
 else


### PR DESCRIPTION
Same fix as #86, applied to the copy it missed: `ugreen-netdevmon-multi` still writes `LED_INVERT` to `/sys/class/leds/netdev/invert`, but the netdev trigger (`ledtrig-netdev`) has no `invert` attribute. The trigger exposes `device_name`, `link`, `tx`, `rx`, `interval` (and `hw_control`/`offloaded` on newer kernels). The write therefore fails with "No such file or directory" on every service start; it's harmless noise (the script doesn't run `set -e`), but noise nonetheless.

`LED_INVERT` keeps working where the attribute actually exists —> the oneshot trigger used by `ugreen-diskiomon`.