### PR TITLE
check-standby: retry failed power mode checks instead of disabling the device

### DIFF
--- a/scripts/check-standby.cpp
+++ b/scripts/check-standby.cpp
@@ -11,18 +11,22 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 
-std::optional<bool> is_standby_mode(const std::string &device) {
+std::optional<bool> is_standby_mode(const std::string &device, bool log_errors) {
 
     int fd = open(device.c_str(), O_RDONLY | O_NONBLOCK);
     if (fd == -1) {
-        std::cerr << "Failed to open device: " << device << std::endl;
+        if (log_errors)
+            std::cerr << "Failed to open device: " << device
+                << " (will retry every cycle)" << std::endl;
         return std::nullopt;
     }
 
     unsigned char args[4] = { WIN_CHECKPOWERMODE1, 0, 0, 0 };
 
     if (ioctl(fd, HDIO_DRIVE_CMD, args) == -1) {
-        std::cerr << "ioctl failed in checking power mode of " << device << std::endl;
+        if (log_errors)
+            std::cerr << "ioctl failed in checking power mode of " << device
+                << " (will retry every cycle)" << std::endl;
         close(fd);
         return std::nullopt;
     }
@@ -83,30 +87,48 @@ int main(int argc, char *argv[]) {
                 "/sys/class/leds/" + led_device + "/color");
     }
 
-    std::vector<bool> device_valid(num_devices, true);
     std::vector<bool> device_standby(num_devices, false);
+
+    // Failures can be transient (device busy, controller reset), so a failed
+    // check must not permanently disable a device; retry it every cycle.
+    // These counters only suppress repeated logging while a failure persists.
+    std::vector<long> check_failures(num_devices, 0);
+    std::vector<long> led_failures(num_devices, 0);
 
     while (true) {
         for (int i = 0; i < num_devices; i++) {
 
-            if (!device_valid[i]) {
+            auto is_standby = is_standby_mode(block_device_paths[i],
+                    check_failures[i] == 0);
+
+            if (!is_standby.has_value()) {
+                ++check_failures[i];
                 continue;
             }
 
-            auto is_standby = is_standby_mode(block_device_paths[i]);
-
-            if (!is_standby.has_value()) {
-                device_valid[i] = false;
-                continue;
+            if (check_failures[i] > 0) {
+                std::cerr << "Power mode check of " << block_device_paths[i]
+                    << " recovered after " << check_failures[i]
+                    << " failed cycles" << std::endl;
+                check_failures[i] = 0;
             }
 
             if (is_standby.value() != device_standby[i]) {
                 std::fstream led_color(led_device_color_paths[i], std::ios::in | std::ios::out);
                 if (!led_color) {
-                    std::cerr << "Failed to open led color file: " 
-                        << led_device_color_paths[i] << std::endl;
-                    device_valid[i] = false;
+                    if (led_failures[i] == 0)
+                        std::cerr << "Failed to open led color file: "
+                            << led_device_color_paths[i]
+                            << " (will retry every cycle)" << std::endl;
+                    ++led_failures[i];
                     continue;
+                }
+
+                if (led_failures[i] > 0) {
+                    std::cerr << "Opening led color file " << led_device_color_paths[i]
+                        << " recovered after " << led_failures[i]
+                        << " failed cycles" << std::endl;
+                    led_failures[i] = 0;
                 }
 
                 std::string current_color;

--- a/scripts/check-standby.cpp
+++ b/scripts/check-standby.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <chrono>
 #include <optional>
+#include <limits>
 
 #include <fcntl.h>
 #include <linux/hdreg.h>
@@ -102,7 +103,9 @@ int main(int argc, char *argv[]) {
                     check_failures[i] == 0);
 
             if (!is_standby.has_value()) {
-                ++check_failures[i];
+                // saturate so a persistent failure cannot overflow the counter
+                if (check_failures[i] < std::numeric_limits<long>::max())
+                    ++check_failures[i];
                 continue;
             }
 
@@ -120,7 +123,9 @@ int main(int argc, char *argv[]) {
                         std::cerr << "Failed to open led color file: "
                             << led_device_color_paths[i]
                             << " (will retry every cycle)" << std::endl;
-                    ++led_failures[i];
+                    // saturate so a persistent failure cannot overflow the counter
+                    if (led_failures[i] < std::numeric_limits<long>::max())
+                        ++led_failures[i];
                     continue;
                 }
 


### PR DESCRIPTION
## Problem

In `scripts/check-standby.cpp`, any failed `open()` or `HDIO_DRIVE_CMD` ioctl sets `device_valid[i] = false`, which is never reset:

```cpp
auto is_standby = is_standby_mode(block_device_paths[i]);
if (!is_standby.has_value()) {
    device_valid[i] = false;
    continue;
}
```

These failures can be transient (device busy under heavy I/O, controller reset, hotplug), but one occurrence permanently stops the standby/normal color updates for that slot until the monitor is restarted. The LED then silently shows a stale power state. The same permanent latch exists for a transient failure to open the LED's sysfs color file.

## Fix

Treat both failures as transient: keep checking the device every cycle instead of disabling it. Per-device failure counters are used only for logging, so the journal gets one line when a failure starts and one line when the check recovers (with the number of failed cycles), rather than one line per check interval while a disk is absent.

The retry itself is essentially free: a failed `open()` returns immediately, and CHECK POWER MODE is answered by the drive electronics without touching the platters, so retries cannot wake a sleeping disk.

The color write logic is unchanged.

## Validation

Tested the compiled binary with an `LD_PRELOAD` shim that fakes `open()`/`ioctl()` for a virtual block device and drives it through each transition (device missing at start, device appears, transient ioctl failure, recovery into standby, LED sysfs open failure while the disk wakes, LED recovery). Output:

```
Failed to open device: /dev/fakedisk (will retry every cycle)
Power mode check of /dev/fakedisk recovered after 10 failed cycles
ioctl failed in checking power mode of /dev/fakedisk (will retry every cycle)
Power mode check of /dev/fakedisk recovered after 10 failed cycles
Failed to open led color file: /sys/class/leds/fakeled/color (will retry every cycle)
Opening led color file /sys/class/leds/fakeled/color recovered after 9 failed cycles
```

The standby/normal color flips were verified to still happen after each recovery, including the pending flip once the LED color file becomes writable again.