### PR TITLE
ugreen-probe-leds: fix unreachable "I2C device not found" fallback under set -e

### DIFF
--- a/scripts/ugreen-probe-leds
+++ b/scripts/ugreen-probe-leds
@@ -33,9 +33,9 @@ if ! lsmod | grep -q led_ugreen; then
     fi
 fi
 
-i2c_dev=$(i2cdetect -l | grep "SMBus I801 adapter" | grep -Po "i2c-\d+")
+i2c_dev=$(i2cdetect -l | grep "SMBus I801 adapter" | grep -Po "i2c-\d+" || true)
 
-if [ $? = 0 ]; then 
+if [ -n "$i2c_dev" ]; then
         echo "Found I2C device /dev/${i2c_dev}"
         dev_path=/sys/bus/i2c/devices/$i2c_dev/${i2c_dev/i2c-/}-003a
         if [ ! -d $dev_path ]; then


### PR DESCRIPTION
The probe script runs with `set -e`, so on hardware without the SMBus I801 adapter this line kills the script:

```bash
i2c_dev=$(i2cdetect -l | grep "SMBus I801 adapter" | grep -Po "i2c-\d+")
```

A failed command substitution in an assignment propagates the pipeline's exit status, so the script exits right there and the `if [ $? = 0 ]` on the next line is never reached. That makes the "I2C device not found!" branch dead code: instead of the intended message you get a silent exit with rc 1, which is annoying to debug in a VM or on a model with a different chipset.

Fixed by appending `|| true` and testing the captured variable instead of `$?`.

Tested on a VM with a stubbed `i2cdetect`:

* before, no I801 in the output: silent exit, rc 1
* after, no I801: prints "I2C device not found!" and exits 0
* with an I801 line present the behavior is unchanged, the script prints "Found I2C device /dev/i2c-5" and continues to the device registration as before