### PR TITLE
Re-enumerate disk LED mapping after SATA hotplug events

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For the process of understanding this control logic, please refer to [my blog (i
 > - [ ] UGREEN DXP2800 GT
 > - [x] UGREEN DXP4800 ([#41](https://github.com/miskcoo/ugreen_leds_controller/issues/41))
 > - [x] UGREEN DXP4800 Plus ([Gist](https://gist.github.com/Kerryliu/c380bb6b3b69be5671105fc23e19b7e8))
-> - [ ] UGREEN DXP4800 Pro
+> - [x] UGREEN DXP4800 Pro ([#116](https://github.com/miskcoo/ugreen_leds_controller/pull/116))
 > - [ ] UGREEN DXP4800 GT (**Experimental**, available on [v0.4-beta](https://github.com/miskcoo/ugreen_leds_controller/releases/tag/v0.4-beta), [#100](https://github.com/miskcoo/ugreen_leds_controller/pull/100))
 > - [x] UGREEN DXP6800 Pro ([#7](https://github.com/miskcoo/ugreen_leds_controller/issues/7))
 > - [x] UGREEN DXP8800 Plus ([#1](https://github.com/miskcoo/ugreen_leds_controller/issues/1), [Repo](https://github.com/meyergru/ugreen_dxp8800_leds_controller))

--- a/README.md
+++ b/README.md
@@ -210,7 +210,11 @@ Please see `scripts/ugreen-leds.conf` for an example.
   cp scripts/ugreen-leds.conf /etc/ugreen-leds.conf
   
   # copy the systemd services
-  cp scripts/systemd/*.service /etc/systemd/system/
+  cp scripts/systemd/*.{service,timer} /etc/systemd/system/
+
+  # refresh disk monitoring when an internal SATA disk is added or removed
+  cp scripts/udev/99-ugreen-diskiomon-hotplug.rules /etc/udev/rules.d/
+  udevadm control --reload-rules
   
   systemctl daemon-reload
   
@@ -225,6 +229,12 @@ Please see `scripts/ugreen-leds.conf` for an example.
   systemctl enable ugreen-diskiomon
   systemctl enable ugreen-power-led
   ```
+
+  The udev rule restarts a two-second systemd timer whenever an internal SATA
+  disk is added or removed. Event bursts are coalesced, then the disk-to-bay
+  mapping is re-enumerated once after the event stream quiets. It does not poll for
+  mapping changes. A clean no-disk exit remains refreshable for the next disk add,
+  while a manually stopped `ugreen-diskiomon.service` remains stopped.
 
 - (_Optional_) To reduce the CPU usage of blinking LEDs when disks are active, you can enter the `scripts` directory and do the following things:
   ```bash

--- a/SPECS/kmod-led-ugreen.spec
+++ b/SPECS/kmod-led-ugreen.spec
@@ -53,6 +53,7 @@ BuildRequires:  kernel-abi-stablelists
 BuildRequires:  kernel-rpm-macros
 BuildRequires:  redhat-rpm-config
 BuildRequires:  systemd-units
+BuildRequires:  systemd-rpm-macros
 BuildRequires:  gcc-c++
 
 Provides:       kernel-modules >= %{kmod_kernel_version}.%{_arch}
@@ -63,6 +64,7 @@ Requires(postun):       %{_sbindir}/weak-modules
 Requires:       kernel >= %{kmod_kernel_version}
 Requires:       kernel-core-uname-r >= %{kmod_kernel_version}
 Requires:       i2c-tools smartmontools dmidecode
+Requires:       systemd systemd-udev
 
 %description
 This package provides the %{kmod_name} kernel module(s) for ugreen_leds_controller.
@@ -116,8 +118,14 @@ mkdir -p %{buildroot}%{_bindir}/
 %{__install} -m 0755 scripts/ugreen-check-standby %{buildroot}%{_bindir}/
 
 mkdir -p %{buildroot}%{_unitdir}/
-%{__install} -m 0644 scripts/ugreen-netdevmon@.service  %{buildroot}%{_unitdir}/
-%{__install} -m 0644 scripts/ugreen-diskiomon.service   %{buildroot}%{_unitdir}/
+%{__install} -m 0644 scripts/systemd/ugreen-probe-leds.service %{buildroot}%{_unitdir}/
+%{__install} -m 0644 scripts/systemd/ugreen-netdevmon@.service %{buildroot}%{_unitdir}/
+%{__install} -m 0644 scripts/systemd/ugreen-diskiomon.service %{buildroot}%{_unitdir}/
+%{__install} -m 0644 scripts/systemd/ugreen-diskiomon-refresh.service %{buildroot}%{_unitdir}/
+%{__install} -m 0644 scripts/systemd/ugreen-diskiomon-refresh.timer %{buildroot}%{_unitdir}/
+
+mkdir -p %{buildroot}%{_udevrulesdir}/
+%{__install} -m 0644 scripts/udev/99-ugreen-diskiomon-hotplug.rules %{buildroot}%{_udevrulesdir}/
 
 # strip the modules(s)
 find %{buildroot} -type f -name \*.ko -exec %{__strip} --strip-debug \{\} \;
@@ -147,6 +155,8 @@ echo "systemctl start  ugreen-diskiomon.service"
 echo "ls /sys/class/leds"
 echo "Make sure you can see disk1, netdev, power, etc."
 echo "systemctl enable ugreen-diskiomon.service"
+systemctl daemon-reload 2>/dev/null || :
+udevadm control --reload-rules 2>/dev/null || :
 echo
 echo "to uninstall:"
 echo "systemctl stop    ugreen-diskiomon.service"
@@ -207,6 +217,11 @@ fi
 modules=( $(cat "%{dup_module_list}") )
 rm -f "%{dup_module_list}"
 printf '%s\n' "${modules[@]}" | %{_sbindir}/weak-modules --remove-modules $initramfs_opt
+if [ "$1" -eq 0 ]; then
+        systemctl stop ugreen-diskiomon-refresh.timer 2>/dev/null || :
+fi
+systemctl daemon-reload 2>/dev/null || :
+udevadm control --reload-rules 2>/dev/null || :
 
 rmdir "%{dup_state_dir}" 2> /dev/null
 
@@ -225,7 +240,11 @@ exit 0
 %attr(0755, root, root) %{_bindir}/ugreen-blink-disk
 %attr(0755, root, root) %{_bindir}/ugreen-check-standby
 %{_unitdir}/ugreen-netdevmon@.service
+%{_unitdir}/ugreen-probe-leds.service
 %{_unitdir}/ugreen-diskiomon.service
+%{_unitdir}/ugreen-diskiomon-refresh.service
+%{_unitdir}/ugreen-diskiomon-refresh.timer
+%{_udevrulesdir}/99-ugreen-diskiomon-hotplug.rules
 
 %changelog
 * Sat Jun 22 2024 Axel Olmos <ax@olmosconsulting.com> - 0.0-14

--- a/build-scripts/debian/build-systemd-deb.sh
+++ b/build-scripts/debian/build-systemd-deb.sh
@@ -13,7 +13,7 @@ Package: $pkgname
 Version: $pkgver
 Architecture: all
 Maintainer: Yuhao Zhou <miskcoo@gmail.com>
-Depends: led-ugreen-utils (>= 0.3), led-ugreen-dkms (>= 0.3), debconf (>= 0.5)
+Depends: led-ugreen-utils (>= 0.3), led-ugreen-dkms (>= 0.3), debconf (>= 0.5), systemd, udev
 Homepage: https://github.com/miskcoo/ugreen_leds_controller
 Description: UGREEN NAS LED systemd services
  Systemd service files for automatic UGREEN NAS LED monitoring.
@@ -268,6 +268,10 @@ if [ "$RET" = "true" ]; then
     esac
 fi
 
+# Load packaged units and hotplug rules without requiring a reboot.
+systemctl daemon-reload 2>/dev/null || true
+udevadm control --reload-rules 2>/dev/null || true
+
 db_stop
 
 exit 0
@@ -292,13 +296,37 @@ systemctl disable 'ugreen-netdevmon@*.service' 2>/dev/null || true
 exit 0
 EOF
 
+cat <<'EOF' > $pkgname/DEBIAN/postrm
+#!/usr/bin/bash
+
+set -e
+
+# Drop removed package rules from udev's in-memory ruleset.
+case "$1" in
+    remove|purge)
+        systemctl stop ugreen-diskiomon-refresh.timer 2>/dev/null || true
+        ;;
+esac
+systemctl daemon-reload 2>/dev/null || true
+udevadm control --reload-rules 2>/dev/null || true
+
+exit 0
+EOF
+
 chmod +x $pkgname/DEBIAN/config
 chmod +x $pkgname/DEBIAN/postinst
 chmod +x $pkgname/DEBIAN/prerm
+chmod +x $pkgname/DEBIAN/postrm
 
 # Install systemd service files
 mkdir -p $pkgname/etc/systemd/system
-cp scripts/systemd/*.service $pkgname/etc/systemd/system/
+install -m 0644 scripts/systemd/*.service $pkgname/etc/systemd/system/
+install -m 0644 scripts/systemd/*.timer $pkgname/etc/systemd/system/
+
+# Debounce internal SATA disk add/remove events so the bay-to-device mapping is
+# re-enumerated once after the event burst, without periodic polling.
+mkdir -p $pkgname/usr/lib/udev/rules.d
+install -m 0644 scripts/udev/99-ugreen-diskiomon-hotplug.rules $pkgname/usr/lib/udev/rules.d/
 
 # Set ownership
 chown -R root:root $pkgname/

--- a/scripts/systemd/ugreen-diskiomon-refresh.service
+++ b/scripts/systemd/ugreen-diskiomon-refresh.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Refresh UGREEN disk LED mapping after hotplug changes
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/systemctl try-restart ugreen-diskiomon.service

--- a/scripts/systemd/ugreen-diskiomon-refresh.timer
+++ b/scripts/systemd/ugreen-diskiomon-refresh.timer
@@ -1,0 +1,7 @@
+[Unit]
+Description=Debounce UGREEN disk LED hotplug events
+
+[Timer]
+OnActiveSec=2s
+AccuracySec=100ms
+Unit=ugreen-diskiomon-refresh.service

--- a/scripts/systemd/ugreen-diskiomon.service
+++ b/scripts/systemd/ugreen-diskiomon.service
@@ -5,6 +5,7 @@ Requires=ugreen-probe-leds.service
 
 [Service]
 ExecStart=/usr/bin/ugreen-diskiomon
+RemainAfterExit=yes
 StandardOutput=journal
 
 [Install]

--- a/scripts/udev/99-ugreen-diskiomon-hotplug.rules
+++ b/scripts/udev/99-ugreen-diskiomon-hotplug.rules
@@ -1,0 +1,5 @@
+# Re-enumerate bay-to-disk mappings after internal SATA disks are added or removed.
+# Import the cached bus on removal because the device is no longer available to probe.
+# Restarting the timer coalesces event bursts; the service refresh runs after they settle.
+ACTION=="remove", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", IMPORT{db}="ID_BUS"
+ACTION=="add|remove", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", ENV{ID_BUS}=="ata", RUN+="/usr/bin/systemctl --no-block restart ugreen-diskiomon-refresh.timer"


### PR DESCRIPTION
# Proposed PR

## Title
Re-enumerate disk LED mapping after SATA hotplug events

## Summary

`ugreen-diskiomon` enumerates installed disks and builds its bay-to-device map only when the service starts. If an internal SATA disk is inserted or removed later, the long-running activity monitor retains the old map. A newly inserted disk therefore has no activity LED until the service is restarted manually.

This change adds an event-driven udev and systemd refresh path. Whole SATA-disk add/remove events restart a two-second timer. Repeated events reset that timer, coalescing an event burst. Once the event stream quiets, a one-shot service asks systemd to restart `ugreen-diskiomon.service` only if it is already active. The existing ATA/HCTL/serial mapping logic then re-enumerates all bays.

This implements the udev-restart direction suggested by the maintainer in #9,
while adding event scoping, debounce, empty-bay handling, and package lifecycle
support.

## Behavior

- Reacts only to whole internal ATA/SATA disks (`DEVTYPE=disk`, `ID_BUS=ata`).
- Imports only the cached `ID_BUS` property on remove events, when the departed
  device can no longer be probed.
- Does not react to partition, USB-storage, SAS, or NVMe events.
- Coalesces rapid add/remove event bursts with a two-second systemd timer.
- Uses `systemctl --no-block` in the udev worker.
- Uses `try-restart` in the refresh service, so a manually stopped `ugreen-diskiomon.service` remains stopped.
- Keeps a clean no-disk exit logically active with `RemainAfterExit=yes`, allowing the next first-disk add event to refresh the mapper.
- Adds no periodic disk-rescan loop.
- Keeps existing ATA, HCTL, and serial mapping behavior unchanged.

## Packaging and documentation

- Install the udev rule and refresh service/timer through the Debian systemd package.
- Add explicit Debian dependencies on `systemd` and `udev`.
- Install the rule and units through the RPM spec.
- Correct the RPM spec's stale systemd source paths and include the required
  `ugreen-probe-leds.service` dependency unit.
- Add explicit RPM dependencies on `systemd-rpm-macros`, `systemd`, and `systemd-udev`.
- Reload systemd and udev state during installation and removal.
- Stop an armed refresh timer during final package removal.
- Document installation for manual Debian setups.

## Validation

- `bash -n scripts/ugreen-diskiomon build-scripts/debian/build-systemd-deb.sh`
- `git diff --check`
- `systemd-analyze verify` on the isolated refresh service/timer unit path
- Live user-systemd verification:
  - clean mapper exit with `RemainAfterExit=yes`: `active/exited`
  - explicit manual stop: `inactive`
- `udevadm verify scripts/udev/99-ugreen-diskiomon-hotplug.rules`
  - 1 rule file checked
  - 1 success
  - 0 failures
- Built `led-ugreen-systemd` with `fakeroot` and `dpkg-deb`
  - refresh service, timer, and udev rule present
  - all packaged with mode `0644`
  - dependencies include `systemd` and `udev`
  - generated `postinst` reloads systemd and udev
  - generated `postrm` stops an armed timer on removal and reloads systemd and udev
- Parsed the RPM spec in a clean Fedora 41 container with `rpm-build` and
  `systemd-rpm-macros`; all new unit and udev paths expanded successfully.
- ShellCheck: clean modified script and clean upstream baseline.
- Static added-line scans found no secrets or dangerous execution patterns.
- Review findings addressed: event races, broad device scope, zero-disk state,
  remove-time udev properties, and Debian/RPM lifecycle handling.
- Hardware mapping reproduced on a UGREEN DXP4800 Pro running a third-party OS:
  - ATA1 mapped to `disk1`
  - ATA2 mapped to `disk2`
  - both devices produced independent activity pulses under sustained I/O

A physical remove/add cycle was not performed while the system was carrying an active ZFS replication workload. The udev rule, timer/service graph, and package lifecycle were validated without interrupting that workload.
